### PR TITLE
feat: implement category path

### DIFF
--- a/src/components/common/category-path/CategoryPath.stories.tsx
+++ b/src/components/common/category-path/CategoryPath.stories.tsx
@@ -1,0 +1,78 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+
+import CategoryPath from './CategoryPath'
+import { useState } from 'react'
+
+const SAMPLE_CATEGORY = ['프론트엔드', '프로그래밍 언어', 'Python']
+
+const meta: Meta<typeof CategoryPath> = {
+  title: 'Common/CategoryPath',
+  component: CategoryPath,
+  tags: ['autodocs'],
+  argTypes: {
+    variant: {
+      control: 'radio',
+      options: ['list', 'detail'],
+    },
+  },
+  args: {
+    path: SAMPLE_CATEGORY,
+    variant: 'list',
+  },
+}
+
+export default meta
+
+type Story = StoryObj<typeof CategoryPath>
+
+const DefaultCategory = () => {
+  return <CategoryPath path={SAMPLE_CATEGORY} variant="list" />
+}
+
+// 기본 스토리 - 목록
+export const Default: Story = {
+  render: () => <DefaultCategory />,
+}
+
+// 답변 상세
+export const DetailCategory: Story = {
+  args: {
+    path: SAMPLE_CATEGORY,
+    variant: 'detail',
+  },
+}
+
+// 클릭 인터랙션
+const InteractiveCategoryPath = () => {
+  const [selectedPath, setSelectedPath] = useState<string[]>([])
+
+  const handleClick = (index: number) => {
+    setSelectedPath(SAMPLE_CATEGORY.slice(0, index + 1))
+  }
+
+  return (
+    <div className="flex flex-col gap-6">
+      <div className="flex gap-2">
+        {SAMPLE_CATEGORY.map((cat, index) => (
+          <button
+            key={cat}
+            onClick={() => handleClick(index)}
+            className="rounded border px-3 py-1 text-sm hover:bg-gray-100"
+          >
+            {cat}
+          </button>
+        ))}
+      </div>
+      {selectedPath.length > 0 && (
+        <div className="flex flex-col gap-4">
+          <CategoryPath path={selectedPath} variant="list" />
+          <CategoryPath path={selectedPath} variant="detail" />
+        </div>
+      )}
+    </div>
+  )
+}
+
+export const Interactive: Story = {
+  render: () => <InteractiveCategoryPath />,
+}

--- a/src/components/common/category-path/CategoryPath.tsx
+++ b/src/components/common/category-path/CategoryPath.tsx
@@ -1,0 +1,65 @@
+import { cva, type VariantProps } from 'class-variance-authority'
+import { ChevronRight } from 'lucide-react'
+import { cn } from '@/utils/cn'
+
+const categoryPathVariants = cva('', {
+  variants: {
+    variant: {
+      detail: 'text-xl font-bold text-[#6201F4]',
+      list: 'text-xs font-normal text-[#4D4D4D]',
+    },
+  },
+  defaultVariants: {
+    variant: 'list',
+  },
+})
+
+type CategoryPathProps = VariantProps<typeof categoryPathVariants> & {
+  path: string[]
+  className?: string
+}
+
+/**
+ * 카테고리 경로를 표시하는 컴포넌트
+ * - list: 목록용
+ * - detail: 상세용
+ *
+ * @example
+ * <CategoryPath path={['프론트엔드', '프로그래밍 언어', 'Python']} variant="list" />
+ */
+export default function CategoryPath({
+  path,
+  variant = 'list',
+  className,
+}: CategoryPathProps) {
+  return (
+    <nav
+      aria-label="category-path"
+      className={cn(
+        'flex items-center',
+        categoryPathVariants({ variant }),
+        className
+      )}
+    >
+      {path.map((item, index) => {
+        const isLast = index === path.length - 1
+        const shouldUnderline = isLast && variant === 'list'
+
+        return (
+          <span key={item} className="flex items-center">
+            <span
+              className={cn(
+                shouldUnderline && 'underline decoration-1 underline-offset-2'
+              )}
+            >
+              {item}
+            </span>
+            {!isLast && (
+              <ChevronRight strokeWidth={2} className="mx-1 h-[1em] w-[1em]" />
+            )}
+          </span>
+        )
+      })}
+    </nav>
+  )
+}

--- a/src/components/index.tsx
+++ b/src/components/index.tsx
@@ -1,3 +1,4 @@
 // components
 export { default as TabButton } from './common/tab-button/TabButton'
 export { default as Avatar } from './common/avatar/Avatar'
+export { default as CategoryPath } from './common/category-path/CategoryPath'


### PR DESCRIPTION
## 📌 관련 이슈

Closes #16 

## ✨ 변경 내용

- CVA 기반 list/detail variant 적용 
- 마지막 항목 언더라인 처리 
- ChevronRight 아이콘 추가 
- Interactive 스토리 추가 
- index.tsx에 배럴 패턴으로 CategoryPath export 추가

## 📸 스크린샷
https://github.com/user-attachments/assets/46f53806-709b-4151-8588-5ce77c27c8a9

## 📚 참고사항
- API 연동 시 `category.names` 배열을 path prop에 바로 전달하면 됩니다.
-   **API 응답 예시**
```json
  "category": {
    "id": 12,
    "depth": 2,
    "names": ["백엔드", "Django", "ORM"]
  }
```

  **사용 예시**
```tsx
  <CategoryPath path={question.category.names} variant="detail" />
```