### PR TITLE
feat: implement answer badge

### DIFF
--- a/src/components/common/answer-badge/AnswerBadge.stories.tsx
+++ b/src/components/common/answer-badge/AnswerBadge.stories.tsx
@@ -1,0 +1,39 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+
+import { AnswerBadge } from '@/components'
+
+const meta: Meta<typeof AnswerBadge> = {
+  title: 'Common/AnswerBadge',
+  component: AnswerBadge,
+  tags: ['autodocs'],
+  args: {
+    variant: 'unanswered',
+    size: 'sm',
+  },
+}
+
+export default meta
+
+type Story = StoryObj<typeof AnswerBadge>
+
+const DefaultAnswerBadge = () => {
+  return <AnswerBadge variant="unanswered" size="sm" />
+}
+
+export const Default: Story = {
+  render: () => <DefaultAnswerBadge />,
+}
+
+export const Answered: Story = {
+  args: {
+    variant: 'answered',
+    size: 'sm',
+  },
+}
+
+export const Detail: Story = {
+  args: {
+    variant: 'detail',
+    size: 'md',
+  },
+}

--- a/src/components/common/answer-badge/AnswerBadge.tsx
+++ b/src/components/common/answer-badge/AnswerBadge.tsx
@@ -1,0 +1,39 @@
+import { cn } from '@/utils/cn'
+import { cva, type VariantProps } from 'class-variance-authority'
+
+const answerBadgeVariants = cva(
+  'flex items-center justify-center rounded-full font-semibold text-white',
+  {
+    variants: {
+      variant: {
+        answered: 'bg-[#04c73d]',
+        unanswered: 'bg-[#bdbdbd]',
+        detail: 'bg-[#6201e0]',
+      },
+      size: {
+        sm: 'w-6 h-6 text-sm',
+        md: 'w-12 h-12 text-[1.75rem]',
+      },
+    },
+    defaultVariants: {
+      variant: 'unanswered',
+      size: 'md',
+    },
+  }
+)
+
+type AnswerBadgeProps = VariantProps<typeof answerBadgeVariants> & {
+  className?: string
+}
+
+export default function AnswerBadge({
+  variant,
+  size,
+  className,
+}: AnswerBadgeProps) {
+  return (
+    <div className={cn(answerBadgeVariants({ variant, size }), className)}>
+      A
+    </div>
+  )
+}

--- a/src/components/index.tsx
+++ b/src/components/index.tsx
@@ -2,3 +2,4 @@
 export { default as TabButton } from './common/tab-button/TabButton'
 export { default as Avatar } from './common/avatar/Avatar'
 export { default as CategoryPath } from './common/category-path/CategoryPath'
+export { default as AnswerBadge } from './common/answer-badge/AnswerBadge'


### PR DESCRIPTION
## 📌 관련 이슈

Closes #18 

## ✨ 변경 내용

- CVA 기반 variant 적용 (answered / unanswered / detail)
  - answered: 초록(#04C73D) — 목록에서 답변 있을 때
  - unanswered: 회색(#BDBDBD) — 목록에서 답변 없을 때
  - detail: 보라(#6201E0) — 상세 페이지 답변 표시
- 사이즈 2종 적용 (sm: 24px / lg: 48px)
- Storybook 스토리 작성
- index.tsx에 배럴 패턴으로 AnswerBadge export 추가

## 📸 스크린샷
<img width="1138" height="762" alt="image" src="https://github.com/user-attachments/assets/eaa87d9d-41a8-4657-a135-b8c6566071ff" />


## 📚 참고사항
