### PR TITLE
feat: add Button component

### DIFF
--- a/src/components/common/button/Button.stories.tsx
+++ b/src/components/common/button/Button.stories.tsx
@@ -1,0 +1,53 @@
+import { Button } from '@/components'
+import type { Meta, StoryObj } from '@storybook/react-vite'
+
+const meta: Meta<typeof Button> = {
+  title: 'Components/Button',
+  component: Button,
+  tags: ['autodocs'],
+  argTypes: {
+    variant: {
+      control: 'select',
+      options: ['primary', 'outline'],
+    },
+    size: {
+      control: 'select',
+      options: ['sm', 'md'],
+    },
+  },
+}
+
+export default meta
+
+type Story = StoryObj<typeof Button>
+
+export const Primary: Story = {
+  args: {
+    children: 'Primary Button',
+    variant: 'primary',
+    size: 'md',
+  },
+}
+
+export const Outline: Story = {
+  args: {
+    children: 'Outline Button',
+    variant: 'outline',
+    size: 'md',
+    // disabled: true,
+  },
+}
+
+export const Small: Story = {
+  args: {
+    children: '확인',
+    size: 'sm',
+  },
+}
+
+export const Disabled: Story = {
+  args: {
+    children: 'Disabled Button ㅅㅅㅅㅅ',
+    disabled: true,
+  },
+}

--- a/src/components/common/button/Button.stories.tsx
+++ b/src/components/common/button/Button.stories.tsx
@@ -1,5 +1,6 @@
 import { Button } from '@/components'
 import type { Meta, StoryObj } from '@storybook/react-vite'
+import { ChevronDown, Filter } from 'lucide-react'
 
 const meta: Meta<typeof Button> = {
   title: 'Components/Button',
@@ -8,11 +9,15 @@ const meta: Meta<typeof Button> = {
   argTypes: {
     variant: {
       control: 'select',
-      options: ['primary', 'outline'],
+      options: ['primary', 'outline', 'soft', 'text'],
     },
     size: {
       control: 'select',
-      options: ['sm', 'md'],
+      options: ['xs', 'sm', 'md', 'lg'],
+    },
+    rounded: {
+      control: 'select',
+      options: ['md', 'full'],
     },
   },
 }
@@ -25,29 +30,57 @@ export const Primary: Story = {
   args: {
     children: 'Primary Button',
     variant: 'primary',
-    size: 'md',
+    size: 'lg',
   },
 }
 
 export const Outline: Story = {
   args: {
-    children: 'Outline Button',
+    children: '답변 수정하기',
     variant: 'outline',
-    size: 'md',
-    // disabled: true,
+    rounded: 'full',
+    size: 'sm',
   },
 }
 
 export const Small: Story = {
   args: {
     children: '확인',
+    rounded: 'full',
     size: 'sm',
+  },
+}
+
+export const Text: Story = {
+  args: {
+    children: '필터',
+    variant: 'text',
+    size: 'sm',
+    rounded: 'full',
+    leftIcon: <Filter className="h-4 w-4" />,
+  },
+}
+
+export const textAccent: Story = {
+  args: {
+    children: '최신순',
+    variant: 'textAccent',
+    size: 'md',
+  },
+}
+
+export const WithRightIcon: Story = {
+  args: {
+    children: '최신순',
+    variant: 'text',
+    size: 'sm',
+    rightIcon: <ChevronDown className="ml-10 h-10 w-10" />,
   },
 }
 
 export const Disabled: Story = {
   args: {
-    children: 'Disabled Button ㅅㅅㅅㅅ',
+    children: 'Disabled Button',
     disabled: true,
   },
 }

--- a/src/components/common/button/Button.stories.tsx
+++ b/src/components/common/button/Button.stories.tsx
@@ -1,6 +1,5 @@
 import { Button } from '@/components'
 import type { Meta, StoryObj } from '@storybook/react-vite'
-import { ChevronDown, Filter } from 'lucide-react'
 
 const meta: Meta<typeof Button> = {
   title: 'Components/Button',
@@ -57,7 +56,6 @@ export const Text: Story = {
     variant: 'text',
     size: 'sm',
     rounded: 'full',
-    leftIcon: <Filter className="h-4 w-4" />,
   },
 }
 
@@ -74,7 +72,6 @@ export const WithRightIcon: Story = {
     children: '최신순',
     variant: 'text',
     size: 'sm',
-    rightIcon: <ChevronDown className="ml-10 h-10 w-10" />,
   },
 }
 

--- a/src/components/common/button/Button.tsx
+++ b/src/components/common/button/Button.tsx
@@ -1,36 +1,31 @@
 import { cn } from '@/utils/cn'
+import type { VariantProps } from 'class-variance-authority'
+import { buttonVariants } from './button.styles'
 
-interface ButtonProps extends React.ComponentProps<'button'> {
-  variant?: 'primary' | 'outline'
-  size?: 'sm' | 'md'
-}
-
-const baseClasses =
-  'inline-flex items-center justify-center font-semibold transition-colors disabled:cursor-not-allowed disabled:pointer-events-none disabled:bg-surface-disabled disabled:text-text-disabled'
-const variants = {
-  primary:
-    'bg-primary text-white hover:bg-primary-hover active:bg-primary-active',
-  outline:
-    'border border-primary text-primary bg-primary-100 disabled:text-text-sub disabled:border disabled:border-border-line',
-}
-const sizes = {
-  sm: 'py-3 px-6 rounded-full',
-  md: 'px-9 py-4 rounded',
+interface ButtonProps
+  extends React.ComponentProps<'button'>, VariantProps<typeof buttonVariants> {
+  leftIcon?: React.ReactNode
+  rightIcon?: React.ReactNode
 }
 
 export default function Button({
   variant = 'primary',
   size = 'md',
+  rounded = 'md',
   className = '',
   children,
+  leftIcon,
+  rightIcon,
   ...props
 }: ButtonProps) {
   return (
     <button
-      className={cn(baseClasses, variants[variant], sizes[size], className)}
+      className={cn(buttonVariants({ variant, size, rounded }), className)}
       {...props}
     >
+      {leftIcon && <span>{leftIcon}</span>}
       {children}
+      {rightIcon && <span>{rightIcon}</span>}
     </button>
   )
 }

--- a/src/components/common/button/Button.tsx
+++ b/src/components/common/button/Button.tsx
@@ -3,10 +3,7 @@ import type { VariantProps } from 'class-variance-authority'
 import { buttonVariants } from './button.styles'
 
 interface ButtonProps
-  extends React.ComponentProps<'button'>, VariantProps<typeof buttonVariants> {
-  leftIcon?: React.ReactNode
-  rightIcon?: React.ReactNode
-}
+  extends React.ComponentProps<'button'>, VariantProps<typeof buttonVariants> {}
 
 export default function Button({
   variant = 'primary',
@@ -14,8 +11,6 @@ export default function Button({
   rounded = 'md',
   className = '',
   children,
-  leftIcon,
-  rightIcon,
   ...props
 }: ButtonProps) {
   return (
@@ -23,9 +18,7 @@ export default function Button({
       className={cn(buttonVariants({ variant, size, rounded }), className)}
       {...props}
     >
-      {leftIcon && <span>{leftIcon}</span>}
       {children}
-      {rightIcon && <span>{rightIcon}</span>}
     </button>
   )
 }

--- a/src/components/common/button/Button.tsx
+++ b/src/components/common/button/Button.tsx
@@ -1,0 +1,36 @@
+import { cn } from '@/utils/cn'
+
+interface ButtonProps extends React.ComponentProps<'button'> {
+  variant?: 'primary' | 'outline'
+  size?: 'sm' | 'md'
+}
+
+const baseClasses =
+  'inline-flex items-center justify-center font-semibold transition-colors disabled:cursor-not-allowed disabled:pointer-events-none disabled:bg-surface-disabled disabled:text-text-disabled'
+const variants = {
+  primary:
+    'bg-primary text-white hover:bg-primary-hover active:bg-primary-active',
+  outline:
+    'border border-primary text-primary bg-primary-100 disabled:text-text-sub disabled:border disabled:border-border-line',
+}
+const sizes = {
+  sm: 'py-3 px-6 rounded-full',
+  md: 'px-9 py-4 rounded',
+}
+
+export default function Button({
+  variant = 'primary',
+  size = 'md',
+  className = '',
+  children,
+  ...props
+}: ButtonProps) {
+  return (
+    <button
+      className={cn(baseClasses, variants[variant], sizes[size], className)}
+      {...props}
+    >
+      {children}
+    </button>
+  )
+}

--- a/src/components/common/button/button.styles.ts
+++ b/src/components/common/button/button.styles.ts
@@ -1,0 +1,34 @@
+import { cva } from 'class-variance-authority'
+
+export const buttonVariants = cva(
+  `inline-flex items-center justify-center font-semibold transition-colors disabled:cursor-not-allowed disabled:pointer-events-none disabled:bg-surface-disabled disabled:text-text-disabled`,
+  {
+    variants: {
+      variant: {
+        primary:
+          'bg-primary text-white hover:bg-primary-hover active:bg-primary-active',
+        outline:
+          'border border-primary text-primary bg-primary-100 disabled:text-text-sub disabled:border disabled:border-border-line',
+        text: 'bg-transparent text-text-main hover:bg-surface-sub',
+        textAccent:
+          'bg-transparent text-primary hover:bg-primary-100 hover:font-bold',
+        textMuted:
+          'bg-transparent text-text-sub hover:bg-gray-200 active:bg-primary-100 active:text-primary',
+      },
+      size: {
+        sm: 'px-5 py-2.5',
+        md: 'px-6 py-3',
+        lg: 'px-9 py-4',
+      },
+      rounded: {
+        md: 'rounded',
+        full: 'rounded-full',
+      },
+    },
+    defaultVariants: {
+      variant: 'primary',
+      size: 'lg',
+      rounded: 'md',
+    },
+  }
+)

--- a/src/components/index.tsx
+++ b/src/components/index.tsx
@@ -1,6 +1,7 @@
 // components
-export { default as TabButton } from './common/tab-button/TabButton'
-export { default as Avatar } from './common/avatar/Avatar'
-export { default as CategoryPath } from './common/category-path/CategoryPath'
 export { default as AnswerBadge } from './common/answer-badge/AnswerBadge'
+export { default as Avatar } from './common/avatar/Avatar'
+export { default as Button } from './common/button/Button'
+export { default as CategoryPath } from './common/category-path/CategoryPath'
 export { default as Loading } from './common/loading/Loading'
+export { default as TabButton } from './common/tab-button/TabButton'


### PR DESCRIPTION
## 📌 관련 이슈

Closes #31

## ✨ 변경 내용
 - 공통 Button 컴포넌트 구현
 - primary, outline variant 스타일 추가
 - sm, md size 옵션 추가
 - base, outline에 disabled 상태 스타일 적용
 - Storybook 스토리(Button.stories) 추가
 - button.styles.ts 로 분리
 - cva 기반 variant 관리

## 📸 스크린샷(선택)
<img width="1992" height="2128" alt="localhost_6007__path=_docs_components-button--docs" src="https://github.com/user-attachments/assets/7ebb73b9-e49c-4930-ab93-704cfda957c6" />

## 📚 참고사항
- 텍스트 버튼의 역할을 구분하기 위해 다음 variant를 정의했습니다.
  - `text`: 기본 텍스트 버튼(예:필터버튼)
  - `textAccent`: 강조 텍스트 버튼 (예: 수정버튼)
  - `textMuted`: 보조 액션용 텍스트 버튼
