### PR TITLE
refactor: extract useOutsideClick hook 

### DIFF
--- a/src/components/common/dropdown/Dropdown.tsx
+++ b/src/components/common/dropdown/Dropdown.tsx
@@ -1,7 +1,10 @@
 import { Button } from '@/components'
+import useOutsideClick from '@/hooks/useOutsideClick'
 import { cn } from '@/utils/cn'
 import { Check, ChevronDown, ChevronUp } from 'lucide-react'
 import { useCallback, useEffect, useRef, useState } from 'react'
+
+type SetValueAction<T> = T | ((prev: T) => T)
 
 function useControllableState<T>(
   controlledValue: T | undefined,
@@ -20,13 +23,16 @@ function useControllableState<T>(
   const value = isControlled ? controlledValue : internalValue
 
   const setValue = useCallback(
-    (next: T) => {
+    (next: SetValueAction<T>) => {
+      const resolvedValue =
+        typeof next === 'function' ? (next as (prev: T) => T)(value) : next
+
       if (!isControlled) {
-        setInternalValue(next)
+        setInternalValue(resolvedValue)
       }
-      onChangeRef.current?.(next)
+      onChangeRef.current?.(resolvedValue)
     },
-    [isControlled]
+    [isControlled, value]
   )
 
   return [value, setValue] as const
@@ -48,6 +54,7 @@ type DropdownProps = {
   disabled?: boolean
   className?: string
 }
+
 export default function Dropdown({
   variant = 'overlay',
   options,
@@ -66,22 +73,10 @@ export default function Dropdown({
   )
   const dropdownRef = useRef<HTMLDivElement | null>(null)
 
-  useEffect(() => {
-    const handleOutsideClick = (e: MouseEvent) => {
-      if (!dropdownRef.current?.contains(e.target as Node)) {
-        setOpen(false)
-      }
-    }
-
-    document.addEventListener('pointerdown', handleOutsideClick)
-
-    return () => {
-      document.removeEventListener('pointerdown', handleOutsideClick)
-    }
-  }, [setOpen])
+  useOutsideClick(dropdownRef, () => setOpen(false))
 
   const handleClick = () => {
-    setOpen(!isOpen)
+    setOpen((prev) => !prev)
   }
 
   const handleSelect = (option: Option) => {

--- a/src/components/common/modal-button/ModalButton.tsx
+++ b/src/components/common/modal-button/ModalButton.tsx
@@ -1,7 +1,12 @@
-import { useEffect, useRef, useState } from 'react'
-import type { MouseEventHandler, ComponentPropsWithRef } from 'react'
 import { ArrowUpDown } from 'lucide-react'
+import {
+  useRef,
+  useState,
+  type ComponentPropsWithRef,
+  type MouseEventHandler,
+} from 'react'
 
+import useOutsideClick from '@/hooks/useOutsideClick'
 import { cn } from '@/utils/cn'
 
 type ModalOption = {
@@ -34,22 +39,7 @@ export default function ModalButton({
   const [open, setOpen] = useState(false)
   const wrapperRef = useRef<HTMLDivElement>(null)
 
-  useEffect(() => {
-    const handleClickOutside = (event: MouseEvent) => {
-      if (
-        wrapperRef.current &&
-        !wrapperRef.current.contains(event.target as Node)
-      ) {
-        setOpen(false)
-      }
-    }
-
-    document.addEventListener('mousedown', handleClickOutside)
-
-    return () => {
-      document.removeEventListener('mousedown', handleClickOutside)
-    }
-  }, [])
+  useOutsideClick(wrapperRef, () => setOpen(false))
 
   const selectedOption = options.find((option) => option.value === value)
 
@@ -87,7 +77,7 @@ export default function ModalButton({
       </button>
 
       {open && !disabled && (
-        <div className="bg-surface-default absolute top-full left-0 z-50 mt-2 w-28 rounded-md px-4 py-5 shadow-[var(--shadow-modal)]">
+        <div className="bg-surface-default shadow-modal absolute top-full left-0 z-50 mt-2 w-28 rounded-md px-4 py-5">
           <ul role="listbox" className="flex flex-col gap-1">
             {options.map((option) => {
               const isSelected = option.value === value

--- a/src/hooks/useOutsideClick.ts
+++ b/src/hooks/useOutsideClick.ts
@@ -1,0 +1,30 @@
+import { useEffect, useRef, type RefObject } from 'react'
+
+function useOutsideClick<T extends HTMLElement>(
+  ref: RefObject<T | null>,
+  onOutsideClick: () => void
+) {
+  const onOutsideClickRef = useRef(onOutsideClick)
+
+  useEffect(() => {
+    onOutsideClickRef.current = onOutsideClick
+  }, [onOutsideClick])
+
+  useEffect(() => {
+    const handleOutsideClick = (e: PointerEvent) => {
+      if (!ref.current) return
+
+      if (!ref.current.contains(e.target as Node)) {
+        onOutsideClickRef.current()
+      }
+    }
+
+    document.addEventListener('pointerdown', handleOutsideClick)
+
+    return () => {
+      document.removeEventListener('pointerdown', handleOutsideClick)
+    }
+  }, [ref])
+}
+
+export default useOutsideClick

--- a/src/index.css
+++ b/src/index.css
@@ -97,8 +97,8 @@ body {
 
   /* Shadow */
 
-  --shadow-box-color: var(--shadow-box);
-  --shadow-modal-color: var(--shadow-modal);
+  --shadow-box-color: var(--shadow-box-value);
+  --shadow-modal-color: var(--shadow-modal-value);
 
   /*Overlay*/
   --bg-overlay: var(--gray-primary);


### PR DESCRIPTION
## 📌 관련 이슈

Closes #46

## ✨ 변경 내용
- 외부 영역 클릭 시 닫히는 로직을 `useOutsideClick` 훅으로 분리
- Modal, Dropdown 컴포넌트에서 공통 훅을 사용하도록 적용
- ModalButton 컴포넌트의 shadow 스타일을 디자인 토큰 방식으로 사용할 수 있도록 수정
- shadow 토큰 사용을 위해 `index.css` 스타일 일부 정리

## 📸 스크린샷(선택)

## 📚 참고사항
- 공통 로직을 훅으로 분리하여 Modal / Dropdown 컴포넌트에서 재사용 가능하도록 구조 개선