### PR TITLE
feat: add EmptyState component and update error constants 

### DIFF
--- a/src/assets/images/empty-state.svg
+++ b/src/assets/images/empty-state.svg
@@ -1,0 +1,9 @@
+<svg width="73" height="68" viewBox="0 0 73 68" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect x="1" y="1" width="54.7606" height="66" rx="6" fill="white" stroke="#BDBDBD" stroke-width="2"/>
+<path d="M40.5491 23H11.1406" stroke="#BDBDBD" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M40.5491 31H11.1406" stroke="#BDBDBD" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M19.2533 15H15.197H11.1406" stroke="#BDBDBD" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M51.1818 52.7483C58.5973 52.7483 64.6087 46.7369 64.6087 39.3214C64.6087 31.906 58.5973 25.8945 51.1818 25.8945C43.7663 25.8945 37.7549 31.906 37.7549 39.3214C37.7549 46.7369 43.7663 52.7483 51.1818 52.7483Z" fill="white" stroke="#BDBDBD" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M41.7197 39.6937C41.7197 35.2475 44.67 31.4905 48.7197 30.2734" stroke="#BDBDBD" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M68.9722 57.1128L60.916 49.0566" stroke="#BDBDBD" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/components/common/empty-state/EmptyState.tsx
+++ b/src/components/common/empty-state/EmptyState.tsx
@@ -1,0 +1,18 @@
+import { ERROR_CONTENT } from '@/constants/error'
+
+type EmptyStateProps = {
+  type: keyof typeof ERROR_CONTENT
+}
+
+export default function EmptyState({ type }: EmptyStateProps) {
+  const { image, title, description } = ERROR_CONTENT[type]
+  return (
+    <div className="flex h-screen flex-col items-center justify-center gap-5">
+      <img src={image} alt="empty 상태 페이지" />
+      <div className="text-text-light text-center">
+        <p>{title}</p>
+        <p>{description}</p>
+      </div>
+    </div>
+  )
+}

--- a/src/components/common/tab-button/TabButton.stories.tsx
+++ b/src/components/common/tab-button/TabButton.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react-vite'
 import { useState } from 'react'
 
-import { TabButton } from '@/components'
+import { TabButton, EmptyState } from '@/components'
 
 const SAMPLE_TABS = [
   { value: 'all', label: '전체보기' },
@@ -66,4 +66,19 @@ const TwoTabsButton = () => {
 
 export const TwoTabs: Story = {
   render: () => <TwoTabsButton />,
+}
+
+// 탭 + EmptyState 조합
+const TabWithEmptyState = () => {
+  const [value, setValue] = useState('all')
+  return (
+    <div className="w-150">
+      <TabButton tabs={SAMPLE_TABS} value={value} onValueChange={setValue} />
+      <EmptyState type="emptyState" />
+    </div>
+  )
+}
+
+export const WithEmptyState: Story = {
+  render: () => <TabWithEmptyState />,
 }

--- a/src/components/index.tsx
+++ b/src/components/index.tsx
@@ -1,4 +1,4 @@
-// components
+// components/common
 export { default as AnswerBadge } from './common/answer-badge/AnswerBadge'
 export { default as Avatar } from './common/avatar/Avatar'
 export { default as Button } from './common/button/Button'
@@ -10,3 +10,4 @@ export { default as Loading } from './common/loading/Loading'
 export { default as Popup } from './common/popup/Popup'
 export { default as TabButton } from './common/tab-button/TabButton'
 export { default as NavButton } from './common/nav-button/NavButton'
+export { default as EmptyState } from './common/empty-state/EmptyState'

--- a/src/constants/error.ts
+++ b/src/constants/error.ts
@@ -1,9 +1,15 @@
 import notFoundImg from '@/assets/images/404.png'
+import emptyState from '@/assets/images/empty-state.svg'
 
 export const ERROR_CONTENT = {
   notFound: {
     image: notFoundImg,
     title: '페이지를 불러올 수 없어요',
     description: '잠시 뒤 다시 시도해보세요!',
+  },
+  emptyState: {
+    image: emptyState,
+    title: '아직 등록된 질문이 없어요',
+    description: '궁금한 점을 남겨보세요!',
   },
 } as const


### PR DESCRIPTION
## 📌 관련 이슈

Closes #51 

## ✨ 변경 내용

- empty-state.svg 이미지 추가
- ERROR_CONTENT에 emptyState 메세지 추가
- EmptyState 컴포넌트 구현
- 배럴패턴 EmptyState 추가
- TabButton 스토리에 WithEmptyState 스토리 추가

## 📸 스크린샷
<img width="835" height="584" alt="image" src="https://github.com/user-attachments/assets/db8ea0d5-d9ce-4285-9b47-356151f0e9ee" />

## 📚 참고사항
`EmptyState` 컴포넌트는 현재 질문 목록 페이지에서만 사용되지만,
추후 다른 페이지(답변 목록 등)에서도 빈 상태 UI가 필요할 수 있어
`features/questions`가 아닌 `common`에 배치했습니다. 
사용 범위가 확정되면 적절한 위치로 파일 이동 부탁드립니다. 🙂