### PR TITLE
feat: add PageContainer and RootLayout 

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,14 +2,17 @@ import { Routes, Route } from 'react-router'
 import './App.css'
 import { NotFoundPage } from '@/pages'
 import { ROUTES_PATHS } from '@/constants/url'
+import { RootLayout } from '@/components'
 
 function App() {
   return (
     <Routes>
-      <Route
-        path={ROUTES_PATHS.NOT_FOUND}
-        element={<NotFoundPage type="notFound" />}
-      />
+      <Route element={<RootLayout />}>
+        <Route
+          path={ROUTES_PATHS.NOT_FOUND}
+          element={<NotFoundPage type="notFound" />}
+        />
+      </Route>
     </Routes>
   )
 }

--- a/src/components/common/page-container/PageContainer.tsx
+++ b/src/components/common/page-container/PageContainer.tsx
@@ -1,0 +1,17 @@
+import { cn } from '@/utils'
+
+type PageContainerProps = {
+  children: React.ReactNode
+  className?: string
+}
+
+export default function PageContainer({
+  children,
+  className,
+}: PageContainerProps) {
+  return (
+    <div className={cn('mx-auto w-full max-w-236 pt-27', className)}>
+      {children}
+    </div>
+  )
+}

--- a/src/components/index.tsx
+++ b/src/components/index.tsx
@@ -11,3 +11,6 @@ export { default as Popup } from './common/popup/Popup'
 export { default as TabButton } from './common/tab-button/TabButton'
 export { default as NavButton } from './common/nav-button/NavButton'
 export { default as EmptyState } from './common/empty-state/EmptyState'
+export { default as PageContainer } from './common/page-container/PageContainer'
+
+export { default as RootLayout } from './layout/RootLayout'

--- a/src/components/layout/RootLayout.tsx
+++ b/src/components/layout/RootLayout.tsx
@@ -1,0 +1,10 @@
+import { Outlet } from 'react-router'
+import { PageContainer } from '@/components'
+
+export default function RootLayout() {
+  return (
+    <PageContainer>
+      <Outlet />
+    </PageContainer>
+  )
+}


### PR DESCRIPTION
## 📌 관련 이슈

Closes #56 

## ✨ 변경 내용

- PageContainer 공통 컴포넌트 구현
- RootLayout 구현 및 Outlet 연결
- App.tsx 라우터 구조 적용
- components/index.ts barrel export 추가

## 📚 참고사항
RootLayout에 Outlet이 PageContainer로 감싸져 있어
사용부에서 별도 컴포넌트 호출 없이 아래와 같이 구현 가능합니다.

```tsx
export default function SomePage() {
  return (
    <div>
      ...
    </div>
  )
}
```

페이지 내 다른 사이즈가 필요한 경우
PageContainer를 직접 호출하여 className으로 오버라이드 해주세요.