### PR TITLE
feat: QNA detail page Header

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,12 +14,8 @@ function App() {
           path={ROUTES_PATHS.NOT_FOUND}
           element={<NotFoundPage type="notFound" />}
         />
+        <Route path={ROUTES_PATHS.QNA_DETAIL} element={<QnaDetailPage />} />
       </Route>
-      <Route
-        path={ROUTES_PATHS.NOT_FOUND}
-        element={<NotFoundPage type="notFound" />}
-      />
-      <Route path="/qna-detail" element={<QnaDetailPage />} />
     </Routes>
   )
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,8 @@ import { NotFoundPage } from '@/pages'
 import { ROUTES_PATHS } from '@/constants/url'
 import { RootLayout } from '@/components'
 
+import QnaDetailPage from '@/pages/qna-detail/QnaDetailPage'
+
 function App() {
   return (
     <Routes>
@@ -13,6 +15,11 @@ function App() {
           element={<NotFoundPage type="notFound" />}
         />
       </Route>
+      <Route
+        path={ROUTES_PATHS.NOT_FOUND}
+        element={<NotFoundPage type="notFound" />}
+      />
+      <Route path="/qna-detail" element={<QnaDetailPage />} />
     </Routes>
   )
 }

--- a/src/components/common/button/button.styles.ts
+++ b/src/components/common/button/button.styles.ts
@@ -14,6 +14,8 @@ export const buttonVariants = cva(
           'bg-transparent text-primary hover:bg-primary-100 hover:font-bold',
         textMuted:
           'bg-transparent text-text-sub hover:bg-gray-200 active:bg-primary-100 active:text-primary',
+        ghost:
+          'text-text-chatbot border-border-line flex gap-1 rounded-full border px-3 py-3 text-xs hover:bg-gray-100',
       },
       size: {
         sm: 'px-5 py-2.5',

--- a/src/constants/url.ts
+++ b/src/constants/url.ts
@@ -1,3 +1,4 @@
 export const ROUTES_PATHS = {
   NOT_FOUND: '*',
+  QNA_DETAIL: '/qna-detail',
 } as const

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,1 +1,2 @@
 export { default as NotFoundPage } from './NotFound'
+export { default as QnaDetailPage } from './qna-detail/QnaDetailPage'

--- a/src/pages/qna-detail/QnaDetailPage.tsx
+++ b/src/pages/qna-detail/QnaDetailPage.tsx
@@ -1,0 +1,34 @@
+// import { useParams } from 'react-router-dom'
+import QnaDetailHeader from './components/QnaDetailHeader'
+import { mockQuestion } from './mock'
+
+export default function QnaDetailPage() {
+  // 임시 데이터용 questionId, 실제로는 API에서 받아올 예정
+  //   const { questionId } = useParams()
+
+  // 지금은 mock 데이터 사용
+  const question = mockQuestion
+
+  const handleShare = () => {
+    const url = window.location.href
+
+    navigator.clipboard.writeText(url)
+    alert('링크가 복사되었습니다.')
+  }
+
+  return (
+    <main className="mx-auto w-full max-w-[960px] px-6 py-10">
+      {/* 질문 헤더 */}
+      <QnaDetailHeader question={question} onShare={handleShare} />
+
+      {/* 답변 영역 (추후 구현) */}
+      <section className="mt-12">
+        <h2 className="text-xl font-semibold">답변 0개</h2>
+
+        <div className="mt-6 rounded-xl border border-gray-200 p-6 text-center text-gray-500">
+          아직 등록된 답변이 없습니다.
+        </div>
+      </section>
+    </main>
+  )
+}

--- a/src/pages/qna-detail/QnaDetailPage.tsx
+++ b/src/pages/qna-detail/QnaDetailPage.tsx
@@ -1,4 +1,5 @@
 // import { useParams } from 'react-router-dom'
+import { EmptyState } from '@/components'
 import QnaDetailHeader from './components/QnaDetailHeader'
 import { mockQuestion } from './mock'
 
@@ -17,18 +18,15 @@ export default function QnaDetailPage() {
   }
 
   return (
-    <main className="mx-auto w-full max-w-[960px] px-6 py-10">
+    <div className="px-8">
       {/* 질문 헤더 */}
       <QnaDetailHeader question={question} onShare={handleShare} />
 
       {/* 답변 영역 (추후 구현) */}
       <section className="mt-12">
         <h2 className="text-xl font-semibold">답변 0개</h2>
-
-        <div className="mt-6 rounded-xl border border-gray-200 p-6 text-center text-gray-500">
-          아직 등록된 답변이 없습니다.
-        </div>
+        <EmptyState type="emptyState" />
       </section>
-    </main>
+    </div>
   )
 }

--- a/src/pages/qna-detail/components/QnaDetailHeader.tsx
+++ b/src/pages/qna-detail/components/QnaDetailHeader.tsx
@@ -7,35 +7,15 @@ type QnaDetailHeaderProps = {
   onShare?: () => void
 }
 
-export default function QnaDetailHeader({ question }: QnaDetailHeaderProps) {
-  const {
-    category_name,
-    sub_category_name,
-    title,
-    content,
-    author,
-    view_count,
-    created_at,
-  } = question
-
-  const categoryPath = [
-    category_name,
-    ...(sub_category_name ? sub_category_name.split(' > ') : []),
-  ]
-
-  const handleCopyLink = async () => {
-    try {
-      await navigator.clipboard.writeText(window.location.href)
-      //   추후 Popup 또는 Toast로 변경 예정
-      alert('링크가 클립보드에 복사되었습니다.')
-    } catch (error) {
-      console.error('클립보드 복사 실패', error)
-    }
-  }
+export default function QnaDetailHeader({
+  question,
+  onShare,
+}: QnaDetailHeaderProps) {
+  const { name, title, content, author, view_count, created_at } = question
 
   return (
     <header className="border-border-line pb-10">
-      <CategoryPath path={categoryPath} variant="detail" className="mb-4" />
+      <CategoryPath path={name} variant="detail" className="mb-4" />
       <div className="flex items-start justify-between gap-4">
         <div className="flex min-w-0 flex-1 items-start gap-3">
           <span className="text-primary text-6xl leading-none font-bold">
@@ -68,12 +48,7 @@ export default function QnaDetailHeader({ question }: QnaDetailHeaderProps) {
           </div>
         </div>
 
-        <Button
-          variant="ghost"
-          size="sm"
-          rounded="full"
-          onClick={handleCopyLink}
-        >
+        <Button variant="ghost" size="sm" rounded="full" onClick={onShare}>
           <Link className="h-4 w-4" />
           공유하기
         </Button>

--- a/src/pages/qna-detail/components/QnaDetailHeader.tsx
+++ b/src/pages/qna-detail/components/QnaDetailHeader.tsx
@@ -7,10 +7,7 @@ type QnaDetailHeaderProps = {
   onShare?: () => void
 }
 
-export default function QnaDetailHeader({
-  question,
-  onShare,
-}: QnaDetailHeaderProps) {
+export default function QnaDetailHeader({ question }: QnaDetailHeaderProps) {
   const {
     category_name,
     sub_category_name,

--- a/src/pages/qna-detail/components/QnaDetailHeader.tsx
+++ b/src/pages/qna-detail/components/QnaDetailHeader.tsx
@@ -61,11 +61,7 @@ export default function QnaDetailHeader({
           </div>
         </div>
 
-        <Button
-          variant="outline"
-          size="sm"
-          className="text-text-chatbot border-border-line bg-surface-default flex gap-1 rounded-full border px-3 py-3 text-xs hover:bg-gray-100"
-        >
+        <Button variant="ghost" size="sm" rounded="full">
           <Link className="h-4 w-4" />
           공유하기
         </Button>

--- a/src/pages/qna-detail/components/QnaDetailHeader.tsx
+++ b/src/pages/qna-detail/components/QnaDetailHeader.tsx
@@ -1,5 +1,5 @@
 import type { QnaQuestion } from '../types'
-import { Avatar } from '@/components'
+import { Avatar, Button, CategoryPath } from '@/components'
 import { Link } from 'lucide-react'
 
 type QnaDetailHeaderProps = {
@@ -7,71 +7,72 @@ type QnaDetailHeaderProps = {
   onShare?: () => void
 }
 
-export default function QnaDetailHeader({ question }: QnaDetailHeaderProps) {
+export default function QnaDetailHeader({
+  question,
+  onShare,
+}: QnaDetailHeaderProps) {
   const {
-    category,
-    subCategory,
+    category_name,
+    sub_category_name,
     title,
     content,
     author,
-    viewCount,
-    createdAt,
+    view_count,
+    created_at,
   } = question
+
+  const categoryPath = [
+    category_name,
+    ...(sub_category_name ? sub_category_name.split(' > ') : []),
+  ]
 
   return (
     <header className="border-border-line pb-10">
-      <div className="flex flex-col gap-6">
-        <div className="text-text-sub flex items-center gap-2 text-sm">
-          <span className="text-primary font-medium">{category}</span>
-          {subCategory && (
-            <>
-              <span>{'>'}</span>
-              <span>{subCategory}</span>
-            </>
-          )}
+      <CategoryPath path={categoryPath} variant="detail" className="mb-4" />
+      <div className="flex items-start justify-between gap-4">
+        <div className="flex min-w-0 flex-1 items-start gap-3">
+          <span className="text-primary text-6xl leading-none font-bold">
+            Q.
+          </span>
+
+          <h1 className="text-text-main text-3xl leading-snug font-bold break-words">
+            {title}
+          </h1>
         </div>
 
-        <div className="flex items-start justify-between gap-4">
-          <div className="flex min-w-0 flex-1 items-start gap-3">
-            <span className="text-primary text-6xl leading-none font-bold">
-              Q.
-            </span>
-
-            <h1 className="text-text-main text-3xl leading-snug font-bold break-words">
-              {title}
-            </h1>
-          </div>
-
-          <div className="m-4 flex shrink-0 items-center gap-2">
-            <Avatar src={author.avatarUrl} alt={author.name} size="md" />
-            <span className="text-text-sub text-sm font-semibold">
-              {author.name}
-            </span>
-          </div>
+        <div className="m-4 flex shrink-0 items-center gap-2">
+          <Avatar src={author.avatar_url} alt={author.name} size="md" />
+          <span className="text-text-sub text-sm font-semibold">
+            {author.name}
+          </span>
         </div>
+      </div>
 
-        <div className="border-border-line flex flex-wrap items-center justify-between gap-4 border-b pb-6">
-          <div className="flex items-center gap-3">
-            <div className="flex flex-col">
-              <div className="flex items-center gap-2"></div>
+      <div className="border-border-line flex flex-wrap items-center justify-between gap-4 border-b pb-4">
+        <div className="flex items-center gap-3">
+          <div className="flex flex-col">
+            <div className="flex items-center gap-2"></div>
 
-              <div className="text-text-light flex items-center gap-2 text-sm">
-                <span>조회수 {viewCount}</span>
-                <span>·</span>
-                <span>{createdAt}</span>
-              </div>
+            <div className="text-text-light flex items-center gap-2 text-sm">
+              <span>조회수 {view_count}</span>
+              <span>·</span>
+              <span>{created_at}</span>
             </div>
           </div>
-
-          <button className="text-text-chatbot border-border-line flex gap-1 rounded-full border px-3 py-3 text-xs hover:bg-gray-100">
-            <Link className="ml-1" size={16} />
-            공유하기
-          </button>
         </div>
 
-        <div className="text-text-primary text-base leading-7 whitespace-pre-line">
-          {content}
-        </div>
+        <Button
+          variant="outline"
+          size="sm"
+          className="text-text-chatbot border-border-line bg-surface-default flex gap-1 rounded-full border px-3 py-3 text-xs hover:bg-gray-100"
+        >
+          <Link className="h-4 w-4" />
+          공유하기
+        </Button>
+      </div>
+
+      <div className="text-text-primary pt-6 text-base leading-7 break-words whitespace-pre-line">
+        {content}
       </div>
     </header>
   )

--- a/src/pages/qna-detail/components/QnaDetailHeader.tsx
+++ b/src/pages/qna-detail/components/QnaDetailHeader.tsx
@@ -44,7 +44,7 @@ export default function QnaDetailHeader({ question }: QnaDetailHeaderProps) {
 
           <div className="m-4 flex shrink-0 items-center gap-2">
             <Avatar src={author.avatarUrl} alt={author.name} size="md" />
-            <span className="text-text-main text-sm font-semibold">
+            <span className="text-text-sub text-sm font-semibold">
               {author.name}
             </span>
           </div>
@@ -55,7 +55,7 @@ export default function QnaDetailHeader({ question }: QnaDetailHeaderProps) {
             <div className="flex flex-col">
               <div className="flex items-center gap-2"></div>
 
-              <div className="text-text-sub flex items-center gap-2 text-sm">
+              <div className="text-text-light flex items-center gap-2 text-sm">
                 <span>조회수 {viewCount}</span>
                 <span>·</span>
                 <span>{createdAt}</span>
@@ -69,7 +69,7 @@ export default function QnaDetailHeader({ question }: QnaDetailHeaderProps) {
           </button>
         </div>
 
-        <div className="text-text-sub text-base leading-7 whitespace-pre-line">
+        <div className="text-text-primary text-base leading-7 whitespace-pre-line">
           {content}
         </div>
       </div>

--- a/src/pages/qna-detail/components/QnaDetailHeader.tsx
+++ b/src/pages/qna-detail/components/QnaDetailHeader.tsx
@@ -1,0 +1,78 @@
+import type { QnaQuestion } from '../types'
+import { Avatar } from '@/components'
+import { Link } from 'lucide-react'
+
+type QnaDetailHeaderProps = {
+  question: QnaQuestion
+  onShare?: () => void
+}
+
+export default function QnaDetailHeader({ question }: QnaDetailHeaderProps) {
+  const {
+    category,
+    subCategory,
+    title,
+    content,
+    author,
+    viewCount,
+    createdAt,
+  } = question
+
+  return (
+    <header className="border-border-line pb-10">
+      <div className="flex flex-col gap-6">
+        <div className="text-text-sub flex items-center gap-2 text-sm">
+          <span className="text-primary font-medium">{category}</span>
+          {subCategory && (
+            <>
+              <span>{'>'}</span>
+              <span>{subCategory}</span>
+            </>
+          )}
+        </div>
+
+        <div className="flex items-start justify-between gap-4">
+          <div className="flex min-w-0 flex-1 items-start gap-3">
+            <span className="text-primary text-6xl leading-none font-bold">
+              Q.
+            </span>
+
+            <h1 className="text-text-main text-3xl leading-snug font-bold break-words">
+              {title}
+            </h1>
+          </div>
+
+          <div className="m-4 flex shrink-0 items-center gap-2">
+            <Avatar src={author.avatarUrl} alt={author.name} size="md" />
+            <span className="text-text-main text-sm font-semibold">
+              {author.name}
+            </span>
+          </div>
+        </div>
+
+        <div className="border-border-line flex flex-wrap items-center justify-between gap-4 border-b pb-6">
+          <div className="flex items-center gap-3">
+            <div className="flex flex-col">
+              <div className="flex items-center gap-2"></div>
+
+              <div className="text-text-sub flex items-center gap-2 text-sm">
+                <span>조회수 {viewCount}</span>
+                <span>·</span>
+                <span>{createdAt}</span>
+              </div>
+            </div>
+          </div>
+
+          <button className="text-text-chatbot border-border-line flex gap-1 rounded-full border px-3 py-3 text-xs hover:bg-gray-100">
+            <Link className="ml-1" size={16} />
+            공유하기
+          </button>
+        </div>
+
+        <div className="text-text-sub text-base leading-7 whitespace-pre-line">
+          {content}
+        </div>
+      </div>
+    </header>
+  )
+}

--- a/src/pages/qna-detail/components/QnaDetailHeader.tsx
+++ b/src/pages/qna-detail/components/QnaDetailHeader.tsx
@@ -26,6 +26,16 @@ export default function QnaDetailHeader({
     ...(sub_category_name ? sub_category_name.split(' > ') : []),
   ]
 
+  const handleCopyLink = async () => {
+    try {
+      await navigator.clipboard.writeText(window.location.href)
+      //   추후 Popup 또는 Toast로 변경 예정
+      alert('링크가 클립보드에 복사되었습니다.')
+    } catch (error) {
+      console.error('클립보드 복사 실패', error)
+    }
+  }
+
   return (
     <header className="border-border-line pb-10">
       <CategoryPath path={categoryPath} variant="detail" className="mb-4" />
@@ -61,7 +71,12 @@ export default function QnaDetailHeader({
           </div>
         </div>
 
-        <Button variant="ghost" size="sm" rounded="full">
+        <Button
+          variant="ghost"
+          size="sm"
+          rounded="full"
+          onClick={handleCopyLink}
+        >
           <Link className="h-4 w-4" />
           공유하기
         </Button>

--- a/src/pages/qna-detail/mock.ts
+++ b/src/pages/qna-detail/mock.ts
@@ -2,8 +2,8 @@ import type { QnaQuestion } from './types'
 
 export const mockQuestion: QnaQuestion = {
   id: 1,
-  category: '프론트엔드',
-  subCategory: '프로그래밍 언어 > Python',
+  category_name: '프론트엔드',
+  sub_category_name: '프로그래밍 언어 > Python',
   title:
     'print를 5번 쓰지 않고, print를 1번만 쓰고 5줄을 모두 표시하는 법이 있나요?',
   content:
@@ -11,9 +11,8 @@ export const mockQuestion: QnaQuestion = {
   author: {
     id: 1,
     name: '김태산',
-    avatarUrl: 'https://avatars.githubusercontent.com/u/12345678?v=4',
-    role: '작성자',
+    avatar_url: 'https://avatars.githubusercontent.com/u/12345678?v=4',
   },
-  viewCount: 60,
-  createdAt: '15시간 전',
+  view_count: 60,
+  created_at: '15시간 전',
 }

--- a/src/pages/qna-detail/mock.ts
+++ b/src/pages/qna-detail/mock.ts
@@ -2,8 +2,7 @@ import type { QnaQuestion } from './types'
 
 export const mockQuestion: QnaQuestion = {
   id: 1,
-  category_name: '프론트엔드',
-  sub_category_name: '프로그래밍 언어 > Python',
+  name: ['프론트엔드', '프로그래밍 언어', 'Python'],
   title:
     'print를 5번 쓰지 않고, print를 1번만 쓰고 5줄을 모두 표시하는 법이 있나요?',
   content:

--- a/src/pages/qna-detail/mock.ts
+++ b/src/pages/qna-detail/mock.ts
@@ -1,0 +1,19 @@
+import type { QnaQuestion } from './types'
+
+export const mockQuestion: QnaQuestion = {
+  id: 1,
+  category: '프론트엔드',
+  subCategory: '프로그래밍 언어 > Python',
+  title:
+    'print를 5번 쓰지 않고, print를 1번만 쓰고 5줄을 모두 표시하는 법이 있나요?',
+  content:
+    'print 명령어를 5번 쓰는 대신 print 한 번만 쓰고 내용을 모두 넣고 표시하는 방법이 있나요?',
+  author: {
+    id: 1,
+    name: '김태산',
+    avatarUrl: 'https://avatars.githubusercontent.com/u/12345678?v=4',
+    role: '작성자',
+  },
+  viewCount: 60,
+  createdAt: '15시간 전',
+}

--- a/src/pages/qna-detail/types.ts
+++ b/src/pages/qna-detail/types.ts
@@ -1,0 +1,17 @@
+export type QnaAuthor = {
+  id: number
+  name: string
+  avatarUrl?: string
+  role?: string
+}
+
+export type QnaQuestion = {
+  id: number
+  category: string
+  subCategory?: string
+  title: string
+  content: string
+  author: QnaAuthor
+  viewCount: number
+  createdAt: string
+}

--- a/src/pages/qna-detail/types.ts
+++ b/src/pages/qna-detail/types.ts
@@ -1,17 +1,16 @@
 export type QnaAuthor = {
   id: number
   name: string
-  avatarUrl?: string
-  role?: string
+  avatar_url?: string
 }
 
 export type QnaQuestion = {
   id: number
-  category: string
-  subCategory?: string
   title: string
   content: string
+  category_name: string
+  sub_category_name?: string
   author: QnaAuthor
-  viewCount: number
-  createdAt: string
+  view_count: number
+  created_at: string
 }

--- a/src/pages/qna-detail/types.ts
+++ b/src/pages/qna-detail/types.ts
@@ -6,10 +6,9 @@ export type QnaAuthor = {
 
 export type QnaQuestion = {
   id: number
+  name: string[]
   title: string
   content: string
-  category_name: string
-  sub_category_name?: string
   author: QnaAuthor
   view_count: number
   created_at: string


### PR DESCRIPTION
## 📌 관련 이슈

Closes #52 

## ✨ 변경 내용
- 질문 상세 페이지에 공통으로 띄우는 헤더 영역입니다.
- 내부 mock 데이터를 추가하여 제목 영역을 미리보기로 대체했습니다.
- 공유하기 버튼의 경우 공통 컴포넌트에 없어서 따로 button 사용했습니다! 아직 따로 버튼에 기능은 없는 상태입니다
- 

## 📸 스크린샷(선택)
<img width="862" height="578" alt="image" src="https://github.com/user-attachments/assets/5458c129-7c42-4f8a-a052-e7d264a9d04d" />


## 📚 참고사항
