### PR TITLE
fix:  responsive qna editor layout

### DIFF
--- a/src/components/common/dropdown/Dropdown.tsx
+++ b/src/components/common/dropdown/Dropdown.tsx
@@ -54,6 +54,8 @@ type DropdownProps = {
   onOpenChange?: (value: boolean) => void
   disabled?: boolean
   className?: string
+  buttonClassName?: string
+  listItemClassName?: string
 }
 
 export default function Dropdown({
@@ -65,6 +67,8 @@ export default function Dropdown({
   onSelect,
   disabled,
   className,
+  buttonClassName,
+  listItemClassName,
 }: DropdownProps) {
   const [isOpen, setOpen] = useControllableState(open, false, onOpenChange)
   const [selectedValue, setSelectedValue] = useControllableState<string | null>(
@@ -95,7 +99,10 @@ export default function Dropdown({
         disabled={disabled}
         variant="ghost"
         onClick={handleClick}
-        className="border-gray-primary flex h-12 w-full justify-between gap-3 border p-4 text-sm font-normal"
+        className={cn(
+          'border-gray-primary flex w-full justify-between gap-3 border p-2 text-sm font-normal md:p-4',
+          buttonClassName
+        )}
       >
         <span>{selectedValue ?? placeHolder}</span>
         {isOpen ? <ChevronUp size={20} /> : <ChevronDown size={20} />}
@@ -115,7 +122,8 @@ export default function Dropdown({
                 onClick={() => handleSelect(item)}
                 className={cn(
                   'hover:bg-primary-100 flex cursor-pointer items-center justify-between p-3',
-                  isSelected && 'text-primary font-semibold'
+                  isSelected && 'text-primary font-semibold',
+                  listItemClassName
                 )}
                 key={item.id}
               >

--- a/src/components/common/input-state/Input.tsx
+++ b/src/components/common/input-state/Input.tsx
@@ -1,4 +1,4 @@
-import type { InputHTMLAttributes } from 'react'
+import { type InputHTMLAttributes, useState } from 'react'
 
 import { cn } from '@/utils/cn'
 
@@ -7,9 +7,16 @@ type InputProps = {
   className?: string
 } & InputHTMLAttributes<HTMLInputElement>
 
-export default function Input({ status, className, ...props }: InputProps) {
+export default function Input({
+  status,
+  className,
+  onBlur,
+  ...props
+}: InputProps) {
+  const [hasBeenFocused, setHasBeenFocused] = useState(false)
+
   const baseClasses =
-    'h-15 rounded border border-transparent bg-primary-100 px-4 text-[18px] text-text-disabled'
+    'h-[clamp(2.75rem,calc(1.768vw+2.336rem),3.75rem)] rounded border border-transparent bg-primary-100 px-4 text-[clamp(0.875rem,calc(0.442vw+0.771rem),1.125rem)] placeholder:text-text-chatbot'
 
   const focusClasses =
     'focus:border-primary focus:bg-transparent focus:text-text-main focus:outline-none'
@@ -17,12 +24,16 @@ export default function Input({ status, className, ...props }: InputProps) {
   const withValueClasses = 'not-placeholder-shown:text-text-main bg-primary-100'
 
   const disabledClasses =
-    'disabled:cursor-not-allowed disabled:bg-surface-disabled'
+    'disabled:cursor-not-allowed disabled:bg-surface-disabled '
 
   const statusClasses = {
     error: 'border-red-500',
     success: 'border-green-500',
   }
+
+  const placeholderClass = hasBeenFocused
+    ? 'placeholder:text-text-disabled'
+    : 'placeholder:text-text-chatbot'
 
   return (
     <input
@@ -31,9 +42,14 @@ export default function Input({ status, className, ...props }: InputProps) {
         focusClasses,
         withValueClasses,
         disabledClasses,
+        placeholderClass,
         status && statusClasses[status],
         className
       )}
+      onBlur={(e) => {
+        setHasBeenFocused(true)
+        onBlur?.(e)
+      }}
       {...props}
     />
   )

--- a/src/components/common/markdown/EditorToolBar.tsx
+++ b/src/components/common/markdown/EditorToolBar.tsx
@@ -16,22 +16,31 @@ export const EditorToolBar = ({ editor }: { editor: Editor | null }) => {
   if (!editor) return null
 
   return (
-    // Toolbar row1
-    <div className="flex flex-col gap-1 border-b border-gray-200 px-3 py-2">
+    <div className="tiptap-toolbar border-border-line flex flex-col gap-1 border-b px-3 py-2">
+      {/* Row 1 - 모바일/데스크탑 공통 핵심 툴 */}
       <div className="flex flex-wrap items-center justify-center gap-x-1">
         <HistoryGroup editor={editor} />
-        <FontGroup editor={editor} />
         <TextFormatGroup editor={editor} />
         <ColorGroup editor={editor} />
         <MediaGroup editor={editor} />
+        {/* 모바일에선 숨김 */}
+        <span className="hidden md:contents">
+          <FontGroup editor={editor} />
+        </span>
       </div>
 
-      {/* Toolbar row2 */}
-      <div className="flex flex-wrap items-center justify-center gap-x-1">
+      {/* Row 2 - 데스크탑만 */}
+      <div className="hidden flex-wrap items-center justify-center gap-x-1 md:flex">
         <ListGroup editor={editor} />
         <AlignGroup editor={editor} />
         <IndentGroup editor={editor} />
         <ClearFormatGroup editor={editor} />
+      </div>
+
+      {/* Row 2 모바일 */}
+      <div className="flex flex-wrap items-center justify-center gap-x-1 md:hidden">
+        <ListGroup editor={editor} />
+        <AlignGroup editor={editor} />
       </div>
     </div>
   )

--- a/src/components/common/markdown/PreviewPanel.tsx
+++ b/src/components/common/markdown/PreviewPanel.tsx
@@ -9,7 +9,7 @@ export default function PreviewPanel({ html }: PreviewProps) {
   const sanitizedHtml = DOMPurify.sanitize(html)
 
   return (
-    <div className="flex-1 overflow-y-auto bg-gray-50/50 px-6 py-4">
+    <div className="hidden flex-1 overflow-y-auto bg-gray-50/50 px-6 py-4 md:flex">
       {isEmpty ? (
         <p className="text-base text-gray-400 select-none">
           내용을 입력해 주세요.

--- a/src/components/common/markdown/TextView.tsx
+++ b/src/components/common/markdown/TextView.tsx
@@ -9,7 +9,7 @@ type TextViewProps = {
 }
 
 export const TextView = ({ editor, previewHtml }: TextViewProps) => (
-  <div className="flex min-h-145 divide-x divide-gray-100">
+  <div className="flex min-h-[clamp(20rem,calc(17.68vw+13.37rem),36.25rem)] divide-x divide-gray-100">
     <EditorPanel editor={editor} />
     <PreviewPanel html={previewHtml} />
   </div>

--- a/src/components/common/markdown/toolbar/groups/ColorGroup.tsx
+++ b/src/components/common/markdown/toolbar/groups/ColorGroup.tsx
@@ -29,10 +29,10 @@ export default function ColorGroup({ editor }: { editor: Editor | null }) {
         type="button"
         title="배경색"
         onClick={() => highlightRef.current?.click()}
-        className="flex h-8 items-center gap-0.5 rounded px-1.5 hover:bg-gray-100"
+        className="flex h-[clamp(1.5rem,calc(0.442vw+1.334rem),2rem)] w-auto! items-center gap-0.5 rounded px-1.5 hover:bg-gray-100"
       >
         <span
-          className="h-4 w-4 rounded-sm border border-gray-300"
+          className="h-[clamp(0.75rem,calc(0.221vw+0.667rem),1rem)] w-[clamp(0.75rem,calc(0.221vw+0.667rem),1rem)] rounded-sm border border-gray-300"
           style={{ backgroundColor: highlight }}
         />
         <ChevronDown size={10} className="text-gray-500" />
@@ -51,14 +51,17 @@ export default function ColorGroup({ editor }: { editor: Editor | null }) {
         type="button"
         title="글자색"
         onClick={() => textColorRef.current?.click()}
-        className="flex h-8 items-center justify-center rounded px-2 hover:bg-gray-100"
+        className="flex h-[clamp(1.5rem,calc(0.442vw+1.334rem),2rem)] w-auto! items-center justify-center rounded px-2 hover:bg-gray-100"
       >
         <span className="flex flex-col items-center leading-none">
-          <span className="text-sm font-bold" style={{ color: textColor }}>
+          <span
+            className="text-[clamp(0.75rem,calc(0.221vw+0.667rem),0.875rem)] font-bold"
+            style={{ color: textColor }}
+          >
             A
           </span>
           <span
-            className="mt-0.5 h-1 w-4 rounded-sm"
+            className="mt-0.5 h-1 w-[clamp(0.75rem,calc(0.221vw+0.667rem),1rem)] rounded-sm"
             style={{ backgroundColor: textColor }}
           />
         </span>

--- a/src/components/common/page-container/PageContainer.tsx
+++ b/src/components/common/page-container/PageContainer.tsx
@@ -12,7 +12,7 @@ export default function PageContainer({
   return (
     <div
       className={cn(
-        'mx-auto flex min-h-screen w-full max-w-236 flex-col pt-27',
+        'mx-auto flex min-h-screen w-full max-w-236 flex-col px-4 pt-27',
         className
       )}
     >

--- a/src/components/common/popup/Popup.tsx
+++ b/src/components/common/popup/Popup.tsx
@@ -27,9 +27,9 @@ export default function Popup({
     >
       <div
         onClick={(e) => e.stopPropagation()}
-        className="bg-surface-default shadow-modal h-auto w-107 rounded-xl p-7"
+        className="bg-surface-default shadow-modal h-auto w-80 rounded-xl p-[clamp(16px,4vw,28px)] sm:w-107"
       >
-        <p className="text-text-modal mb-13 text-base whitespace-pre-line">
+        <p className="text-text-modal mb-13 text-[clamp(0.75rem,3vw,1rem)] whitespace-pre-line">
           {content}
         </p>
         <div className="flex justify-end gap-3">

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,3 +1,4 @@
 //hooks
 
 export { useCommentSort } from './useCommentSort'
+export { useResponsiveDirection } from './useResponsiveDirection'

--- a/src/hooks/useResponsiveDirection.ts
+++ b/src/hooks/useResponsiveDirection.ts
@@ -1,0 +1,17 @@
+import { useEffect, useState } from 'react'
+
+export function useResponsiveDirection() {
+  const [direction, setDirection] = useState<'row' | 'column'>('row')
+
+  useEffect(() => {
+    const mq = window.matchMedia('(max-width: 768px)')
+    const handler = (e: MediaQueryListEvent) =>
+      setDirection(e.matches ? 'column' : 'row')
+
+    setDirection(mq.matches ? 'column' : 'row')
+    mq.addEventListener('change', handler)
+    return () => mq.removeEventListener('change', handler)
+  }, [])
+
+  return direction
+}

--- a/src/index.css
+++ b/src/index.css
@@ -173,7 +173,7 @@ body {
 }
 
 .tiptap-editor > .ProseMirror {
-  min-height: 36rem;
+  min-height: clamp(26rem, calc(17.68vw + 13.37rem), 36rem);
   outline: none;
   cursor: text;
 }
@@ -184,7 +184,25 @@ body {
   pointer-events: none;
   float: left;
   height: 0;
-  font-size: 1rem;
+  font-size: clamp(0.875rem, calc(0.221vw + 0.771rem), 1rem);
+}
+
+.tiptap-editor > .ProseMirror p {
+  font-size: clamp(0.875rem, calc(0.221vw + 0.771rem), 1rem); /* 14px → 16px */
+}
+
+.tiptap-toolbar button {
+  width: clamp(
+    1.5rem,
+    calc(0.442vw + 1.334rem),
+    2rem
+  ) !important; /* 24px → 32px */
+  height: clamp(1.5rem, calc(0.442vw + 1.334rem), 2rem) !important;
+}
+
+.tiptap-toolbar svg {
+  width: clamp(0.875rem, calc(0.221vw + 0.771rem), 1.125rem); /* 14px → 18px */
+  height: clamp(0.875rem, calc(0.221vw + 0.771rem), 1.125rem);
 }
 
 /* 제목 */
@@ -235,7 +253,7 @@ body {
   background: #f3f4f6;
   padding: 0.125rem 0.25rem;
   border-radius: 0.25rem;
-  font-size: 0.875rem;
+  font-size: clamp(0.875rem, calc(0.221vw + 0.771rem), 1rem);
 }
 
 /* Preview 패널 */

--- a/src/pages/qna-create/QnaCreatePage.tsx
+++ b/src/pages/qna-create/QnaCreatePage.tsx
@@ -62,18 +62,17 @@ export default function QnACreatePage({ mode }: QnACreatePageProps) {
 
   return (
     <main className="flex h-auto w-full flex-col">
-      <h1 className="text-text-default mb-5 text-[32px] font-bold">
+      <h1 className="mb-3 text-[clamp(1.5rem,calc(0.884vw+1.293rem),2rem)] leading-tight font-bold md:mb-5">
         질문 작성하기
       </h1>
-      <hr className="border-border-line mb-10 w-full border-[0.5px]" />
+      <hr className="border-border-line mb-6 w-full border-[0.5px] md:mb-10" />
 
       <div className="w-full">
-        <div className="border-border-line mb-5 rounded-2xl border px-9 py-10 md:mb-3 md:rounded-[20px]">
+        <div className="border-border-line mb-3 rounded-2xl border px-5 py-6 md:mb-5 md:rounded-[20px] md:px-9 md:py-10">
           <CategoryDropdown
             categories={categories}
-            direction="row"
             onSelect={handleCategorySelect}
-            className="mb-5"
+            className="mb-3 md:mb-5"
           />
           <Input
             value={title}
@@ -83,18 +82,18 @@ export default function QnACreatePage({ mode }: QnACreatePageProps) {
           />
         </div>
 
-        <div className="border-border-line mb-5 rounded-2xl border md:mb-3 md:rounded-[20px]">
+        <div className="border-border-line mb-3 rounded-2xl border md:mb-5 md:rounded-[20px]">
           <TipTabEditor
             content={content}
             contentChange={(value) => setContent(value ?? '')}
           />
         </div>
       </div>
-      <div className="mt-3 flex w-full justify-end">
+      <div className="mt-8 flex w-full justify-end md:mt-13">
         <Button
           variant="primary"
           size="lg"
-          className="h-13.5 w-35 text-[20px]"
+          className="h-9.5 w-28 p-0 text-[clamp(0.875rem,calc(0.663vw+0.72rem),1.25rem)] md:h-13.5 md:w-35"
           onClick={handleSubmit}
           disabled={isPending}
         >

--- a/src/shared/CategoryDropdown.tsx
+++ b/src/shared/CategoryDropdown.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 
 import { Dropdown } from '@/components'
+import { useResponsiveDirection } from '@/hooks'
 import type { Category } from '@/types/api-response/category'
 import { cn } from '@/utils'
 
@@ -20,11 +21,12 @@ type CategoryDropdownProps = {
 
 export default function CategoryDropdown({
   categories,
-  direction = 'row',
+  direction,
   onSelect,
   className,
   initialValue,
 }: CategoryDropdownProps) {
+  const autoDirection = useResponsiveDirection()
   const [selected, setSelected] = useState<SelectedCategory>(
     initialValue ?? {
       large: null,
@@ -33,51 +35,62 @@ export default function CategoryDropdown({
     }
   )
 
+  const resolvedDirection = direction ?? autoDirection
+
+  const sourceMap: Record<keyof SelectedCategory, Category[] | undefined> = {
+    large: categories,
+    medium: selected.large?.children,
+    small: selected.medium?.children,
+  }
+
   const toOptions = (cats?: Category[]) =>
     cats?.map((c) => ({ id: c.id, value: c.name })) ?? []
 
-  const largeOptions = toOptions(categories)
-  const mediumOptions = toOptions(selected.large?.children)
-  const smallOptions = toOptions(selected.medium?.children)
+  const largeOptions = toOptions(sourceMap.large)
+  const mediumOptions = toOptions(sourceMap.medium)
+  const smallOptions = toOptions(sourceMap.small)
 
   const handleSelect =
     (level: keyof SelectedCategory) =>
     (option: { id: number; value: string }) => {
-      const source =
-        level === 'large'
-          ? categories
-          : level === 'medium'
-            ? selected.large?.children
-            : selected.medium?.children
-
-      const found = source?.find((c) => c.id === option.id)
+      const found = sourceMap[level]?.find((c) => c.id === option.id)
       if (!found) return
 
-      setSelected((prev) => {
-        const newSelected =
-          level === 'large'
-            ? { large: found, medium: null, small: null }
-            : level === 'medium'
-              ? { ...prev, medium: found, small: null }
-              : { ...prev, small: found }
+      const newSelected: SelectedCategory =
+        level === 'large'
+          ? { large: found, medium: null, small: null }
+          : level === 'medium'
+            ? { ...selected, medium: found, small: null }
+            : { ...selected, small: found }
 
-        onSelect(newSelected)
-        return newSelected
-      })
+      setSelected(newSelected)
+      onSelect(newSelected)
     }
 
-  const itemClassName = direction === 'row' ? 'w-1/3' : 'w-full'
+  const itemClassName = resolvedDirection === 'row' ? 'w-1/3' : 'w-full'
+  const rowSizeStyle =
+    'h-[clamp(2.5rem,calc(0.884vw+2.169rem),3rem)] text-[clamp(0.75rem,calc(0.221vw+0.698rem),0.875rem)]'
+
+  const dropdownButtonClassName = cn(
+    resolvedDirection === 'row' && rowSizeStyle
+  )
+
+  const dropdownListItemClassName = cn(
+    resolvedDirection === 'row' ? rowSizeStyle : '!h-6 !py-0 !px-3'
+  )
 
   return (
     <div
       className={cn(
         'flex gap-4',
-        direction === 'column' ? 'flex-col' : 'flex-row',
+        resolvedDirection === 'column' ? 'flex-col' : 'flex-row',
         className
       )}
     >
       <Dropdown
         className={itemClassName}
+        buttonClassName={dropdownButtonClassName}
+        listItemClassName={dropdownListItemClassName}
         value={selected.large?.name ?? null}
         options={largeOptions}
         placeHolder="대분류"
@@ -85,6 +98,8 @@ export default function CategoryDropdown({
       />
       <Dropdown
         className={itemClassName}
+        buttonClassName={dropdownButtonClassName}
+        listItemClassName={dropdownListItemClassName}
         value={selected.medium?.name ?? null}
         options={mediumOptions}
         placeHolder="중분류"
@@ -93,6 +108,8 @@ export default function CategoryDropdown({
       />
       <Dropdown
         className={itemClassName}
+        buttonClassName={dropdownButtonClassName}
+        listItemClassName={dropdownListItemClassName}
         value={selected.small?.name ?? null}
         options={smallOptions}
         placeHolder="소분류"


### PR DESCRIPTION
## 📌 관련 이슈

Closes #82 

## ✨ 변경 내용

### 공통 컴포넌트
- `Dropdown`: `buttonClassName`, `listItemClassName` props 추가로 외부에서 스타일 주입 가능
- `Input`: 높이/폰트 clamp 적용, 포커스 아웃 시 placeholder 색상 분기 처리 (`hasBeenFocused` state)
- `CategoryDropdown`: 768px 기준 row/column 자동 전환, `sourceMap` 리팩토링으로 분기 로직 개선

### 에디터
- `EditorToolBar`: 모바일/데스크탑 노출 아이콘 분기 처리
- `ColorGroup`: 버튼 및 아이콘 크기 반응형 조정 (`w-auto!`로 global CSS 오버라이드)
- `PreviewPanel`: 모바일에서 숨김 처리 (`hidden md:flex`)
- `TextView`: 컨테이너 높이 clamp 적용
- `index.css`: ProseMirror min-height, 폰트 크기, 툴바 버튼/아이콘 크기 clamp 적용

### 페이지/레이아웃
- `QnACreatePage`: 타이틀, 버튼, 패딩/마진 반응형 조정
- `PageContainer`: 모바일 양옆 패딩 조정
- `Popup`: 너비값, 글씨 크기 반응형 적용

## 📸 스크린샷

https://github.com/user-attachments/assets/49054f1f-0142-4272-a2a0-4d3b5ed33788



## 📚 참고사항
- 높이/폰트 크기는 375px(모바일) → 1280px(데스크탑) 기준 clamp 적용
- `!important` 사용은 Tailwind 유틸리티 오버라이드가 필요한 경우에 한정