### PR TITLE
refactor: improve responsive layout on qna list page 

### DIFF
--- a/src/components/common/modal-button/ModalButton.tsx
+++ b/src/components/common/modal-button/ModalButton.tsx
@@ -24,7 +24,9 @@ type ModalButtonProps<T extends string> = Omit<
   onChange: (value: T) => void
   placeholder?: string
   className?: string
+  buttonClassName?: string
   dropdownClassName?: string
+  hideLabelBelowMd?: boolean
 }
 
 export default function ModalButton<T extends string>({
@@ -34,7 +36,9 @@ export default function ModalButton<T extends string>({
   placeholder = '선택',
   disabled = false,
   className,
+  buttonClassName,
   dropdownClassName,
+  hideLabelBelowMd = false,
   type = 'button',
   onClick,
   ...buttonProps
@@ -73,10 +77,12 @@ export default function ModalButton<T extends string>({
           disabled
             ? 'bg-surface-disabled text-text-disabled cursor-not-allowed'
             : 'bg-surface-default text-text-sub border-border-line hover:bg-surface-sub',
-          className
+          buttonClassName
         )}
       >
-        {selectedOption?.label ?? placeholder}
+        <span className={cn(hideLabelBelowMd && 'hidden md:inline')}>
+          {selectedOption?.label ?? placeholder}
+        </span>
         <ArrowDownUp size={20} className="shrink-0" />
       </button>
 

--- a/src/components/common/tab-button/TabButton.tsx
+++ b/src/components/common/tab-button/TabButton.tsx
@@ -19,7 +19,7 @@ export default function TabButton({
   className,
 }: TabProps) {
   return (
-    <div className="border-border-line flex gap-9 border-b">
+    <div className="border-border-line flex gap-2 border-b md:gap-9">
       {tabs.map((tab) => {
         const isSelected = value === tab.value
         return (
@@ -27,7 +27,7 @@ export default function TabButton({
             key={tab.value}
             onClick={() => onValueChange(tab.value)}
             className={cn(
-              'relative px-1 pb-4 text-xl font-bold transition-colors',
+              'relative px-1 pb-4 text-[clamp(1rem,calc(0.442vw+0.896rem),1.8rem)] font-bold transition-colors',
               'after:absolute after:bottom-0 after:left-0 after:h-0.5 after:w-full after:transition-opacity',
               isSelected
                 ? 'text-primary after:bg-primary after:opacity-100'

--- a/src/features/qna-list/components/FilterSidebar.tsx
+++ b/src/features/qna-list/components/FilterSidebar.tsx
@@ -99,7 +99,7 @@ export default function FilterSidebar({
       onClick={onFilterClose}
     >
       <div
-        className="bg-surface-default lg:h-[1080px flex h-195 w-full flex-col rounded-l-xl rounded-bl-xl md:h-270 md:w-135"
+        className="bg-surface-default flex h-195 w-full flex-col rounded-l-xl rounded-bl-xl md:h-270 md:w-135 lg:h-270"
         onClick={(e) => e.stopPropagation()}
       >
         <div className="px-11.5">

--- a/src/features/qna-list/components/FilterSidebar.tsx
+++ b/src/features/qna-list/components/FilterSidebar.tsx
@@ -20,12 +20,23 @@ type FilterSidebarProps = {
 function useBodyScrollLock(isFilterOpen: boolean) {
   useEffect(() => {
     if (!isFilterOpen) {
-      document.body.style.overflow = 'auto'
       return
     }
-    document.body.style.overflow = 'hidden'
+
+    const { body, documentElement } = document
+    const previousOverflow = body.style.overflow
+    const previousPaddingRight = body.style.paddingRight
+    const scrollbarWidth = window.innerWidth - documentElement.clientWidth
+
+    body.style.overflow = 'hidden'
+
+    if (scrollbarWidth > 0) {
+      body.style.paddingRight = `${scrollbarWidth}px`
+    }
+
     return () => {
-      document.body.style.overflow = 'auto'
+      body.style.overflow = previousOverflow
+      body.style.paddingRight = previousPaddingRight
     }
   }, [isFilterOpen])
 }
@@ -84,11 +95,11 @@ export default function FilterSidebar({
 
   return (
     <div
-      className="fixed inset-0 z-50 flex justify-end bg-black/50"
+      className="fixed inset-0 z-50 flex justify-end overflow-hidden bg-black/50"
       onClick={onFilterClose}
     >
       <div
-        className="bg-surface-default flex h-full w-full flex-col rounded-l-xl rounded-bl-xl md:h-270 md:w-135"
+        className="bg-surface-default lg:h-[1080px flex h-195 w-full flex-col rounded-l-xl rounded-bl-xl md:h-270 md:w-135"
         onClick={(e) => e.stopPropagation()}
       >
         <div className="px-11.5">
@@ -127,6 +138,7 @@ export default function FilterSidebar({
                   direction="column"
                   initialValue={pendingSelection}
                   onSelect={setPendingSelection}
+                  className="[&_[data-testid='dropdown']_button]:px-6 [&_[data-testid='dropdown']_button]:py-4 [&_[data-testid='dropdown']_button]:text-base [&_li]:min-h-12 [&_li]:px-5 [&_li]:py-4 [&_span]:text-base [&_ul]:static [&_ul]:p-3"
                 />
               )}
             </div>

--- a/src/features/qna-list/components/QnaCard.tsx
+++ b/src/features/qna-list/components/QnaCard.tsx
@@ -39,7 +39,7 @@ export default function QnaCard({ question, keyword }: QnaCardProps) {
   return (
     <div
       className={cn(
-        'hover:bg-surface-sub flex cursor-pointer flex-col p-10 md:h-52.75 md:flex-row md:items-stretch md:gap-6 md:p-6'
+        'hover:bg-surface-sub flex cursor-pointer flex-col p-4 md:h-52.75 md:flex-row md:items-stretch md:gap-6 md:p-6'
       )}
       onClick={() => navigate(ROUTES_PATHS.QNA_DETAIL_URL(question.id))}
     >

--- a/src/features/qna-list/components/QnaListHeader.tsx
+++ b/src/features/qna-list/components/QnaListHeader.tsx
@@ -1,6 +1,7 @@
+import { useState } from 'react'
 import { useNavigate } from 'react-router'
 
-import { Pencil } from 'lucide-react'
+import { Pencil, Search } from 'lucide-react'
 
 import { Button, SearchBar } from '@/components'
 import { ROUTES_PATHS } from '@/constants/url'
@@ -12,13 +13,40 @@ type QnaListHeaderProps = {
 
 export default function QnaListHeader({ value, onChange }: QnaListHeaderProps) {
   const navigate = useNavigate()
+  const [isSearchOpen, setIsSearchOpen] = useState(false)
 
   return (
     <div className="mb-13 flex w-full flex-col gap-4">
-      <h1 className="text-text-main text-[32px] leading-[1.3] font-bold">
-        질의응답
-      </h1>
       <div className="flex items-center justify-between gap-4">
+        <h1 className="text-text-main text-[clamp(1.5rem,calc(0.884vw+1.293rem),2rem)] leading-[1.3] font-bold">
+          질의응답
+        </h1>
+
+        <div className="flex items-center gap-2 md:hidden">
+          <Button
+            type="button"
+            variant="ghost"
+            size="md"
+            rounded="full"
+            aria-label={isSearchOpen ? '검색창 닫기' : '검색창 열기'}
+            className="h-11 w-11 p-0"
+            onClick={() => setIsSearchOpen((prev) => !prev)}
+          >
+            <Search className="h-5 w-5" />
+          </Button>
+          <Button
+            type="button"
+            rounded="md"
+            aria-label="질문하기"
+            className="h-11 w-11 p-0"
+            onClick={() => navigate(ROUTES_PATHS.QNA_CREATE)}
+          >
+            <Pencil className="h-5 w-5" />
+          </Button>
+        </div>
+      </div>
+
+      <div className="hidden items-center justify-between gap-4 md:flex">
         <SearchBar
           value={value}
           onChange={onChange}
@@ -33,6 +61,16 @@ export default function QnaListHeader({ value, onChange }: QnaListHeaderProps) {
           질문하기
         </Button>
       </div>
+
+      {isSearchOpen && (
+        <div className="md:hidden">
+          <SearchBar
+            value={value}
+            onChange={onChange}
+            className="bg-surface-sub h-11 w-full"
+          />
+        </div>
+      )}
     </div>
   )
 }

--- a/src/index.css
+++ b/src/index.css
@@ -7,7 +7,7 @@ body {
 }
 
 :root {
-  scrollbar-gutter: stable;
+  scrollbar-gutter: auto;
   /* =====================================================
    PRIMITIVE COLOR TOKENS
 ===================================================== */

--- a/src/pages/qna-list/QnaListPage.tsx
+++ b/src/pages/qna-list/QnaListPage.tsx
@@ -56,8 +56,39 @@ export default function QnaListPage() {
   const currentPage = Math.min(page, totalPages)
   const hasNoResults = !isPending && questionsList.length === 0
 
-  // 목록 영역에서만 로딩/에러/빈 상태를 분기하고, 상단 필터 UI는 그대로 유지한다.
-  const isStateView = isPending || isError || hasNoResults
+  const renderContent = () => {
+    if (isPending) {
+      return (
+        <div className="flex flex-1 items-center justify-center">
+          <Loading />
+        </div>
+      )
+    }
+
+    if (isError) {
+      return (
+        <div className="flex flex-1 items-center justify-center">
+          <EmptyState type="notFound" />
+        </div>
+      )
+    }
+
+    if (hasNoResults) {
+      return (
+        <div className="flex flex-1 items-center justify-center">
+          <EmptyState type="searchEmpty" />
+        </div>
+      )
+    }
+
+    return (
+      <div className="space-y-12 md:space-y-0">
+        {questionsList.map((list) => (
+          <QnaCard key={list.id} question={list} keyword={debouncedSearch} />
+        ))}
+      </div>
+    )
+  }
 
   return (
     <div className="flex flex-1 flex-col">
@@ -88,7 +119,7 @@ export default function QnaListPage() {
             }}
           />
 
-          <div className="flex items-center gap-0 pb-4 md:gap-3">
+          <div className="flex items-center pb-4 md:gap-3">
             <ModalButton
               value={sort}
               options={SORT_OPTIONS}
@@ -121,27 +152,7 @@ export default function QnaListPage() {
         </div>
 
         {/* list 목록 */}
-        {isStateView ? (
-          <div className="flex flex-1 items-center justify-center">
-            {isPending ? (
-              <Loading />
-            ) : isError ? (
-              <EmptyState type="notFound" />
-            ) : (
-              <EmptyState type="searchEmpty" />
-            )}
-          </div>
-        ) : (
-          <div className="space-y-12 md:space-y-0">
-            {questionsList.map((list) => (
-              <QnaCard
-                key={list.id}
-                question={list}
-                keyword={debouncedSearch}
-              />
-            ))}
-          </div>
-        )}
+        {renderContent()}
 
         {/*필터 클릭시 사이드바*/}
         <FilterSidebar

--- a/src/pages/qna-list/QnaListPage.tsx
+++ b/src/pages/qna-list/QnaListPage.tsx
@@ -57,37 +57,7 @@ export default function QnaListPage() {
   const hasNoResults = !isPending && questionsList.length === 0
 
   // 목록 영역에서만 로딩/에러/빈 상태를 분기하고, 상단 필터 UI는 그대로 유지한다.
-  const renderContent = () => {
-    //전체 최초 로딩
-    if (isPending) {
-      return (
-        <div className="flex flex-1 items-center justify-center py-20">
-          <Loading />
-        </div>
-      )
-    }
-
-    if (isError) {
-      return (
-        <div className="flex flex-1 flex-col items-center justify-center gap-4">
-          <EmptyState type="notFound" />
-        </div>
-      )
-    }
-
-    //검색 결과 없음
-    if (hasNoResults) {
-      return (
-        <div className="flex flex-1 flex-col items-center justify-center gap-4">
-          <EmptyState type="searchEmpty" />
-        </div>
-      )
-    }
-
-    return questionsList.map((list) => (
-      <QnaCard key={list.id} question={list} keyword={debouncedSearch} />
-    ))
-  }
+  const isStateView = isPending || isError || hasNoResults
 
   return (
     <div className="flex flex-1 flex-col">
@@ -118,7 +88,7 @@ export default function QnaListPage() {
             }}
           />
 
-          <div className="flex items-center gap-3 pb-4">
+          <div className="flex items-center gap-0 pb-4 md:gap-3">
             <ModalButton
               value={sort}
               options={SORT_OPTIONS}
@@ -131,23 +101,47 @@ export default function QnaListPage() {
                   nextPage: 1,
                 })
               }}
-              className="text-modal w-fit p-0 text-base"
+              className="text-modal"
+              buttonClassName="text-modal w-11 md:w-fit p-0 text-base"
               dropdownClassName="w-34.5 right-0 left-auto top-9"
+              hideLabelBelowMd
+              aria-label="정렬 선택"
             />
 
             <Button
-              className="text-modal p-0 font-medium"
+              className="text-modal h-11 w-fit p-0 font-medium md:h-auto"
               variant={'text'}
+              aria-label="필터 열기"
               onClick={() => setIsFilterOpen(true)}
             >
-              필터
-              <SlidersHorizontal size={20} className="ml-1" />
+              <span className="hidden md:inline">필터</span>
+              <SlidersHorizontal size={20} className="md:ml-1" />
             </Button>
           </div>
         </div>
 
         {/* list 목록 */}
-        <div>{renderContent()}</div>
+        {isStateView ? (
+          <div className="flex flex-1 items-center justify-center">
+            {isPending ? (
+              <Loading />
+            ) : isError ? (
+              <EmptyState type="notFound" />
+            ) : (
+              <EmptyState type="searchEmpty" />
+            )}
+          </div>
+        ) : (
+          <div className="space-y-12 md:space-y-0">
+            {questionsList.map((list) => (
+              <QnaCard
+                key={list.id}
+                question={list}
+                keyword={debouncedSearch}
+              />
+            ))}
+          </div>
+        )}
 
         {/*필터 클릭시 사이드바*/}
         <FilterSidebar


### PR DESCRIPTION
## 📌 관련 이슈

Closes #90

## ✨ 변경 내용
  - 질문 목록 페이지 반응형 레이아웃 개선
  - 모바일에서 검색창을 토글형으로 변경
  - 모바일에서 질문하기 버튼을 아이콘 버튼으로 변경
  - 모바일에서 최신순 정렬 버튼을 아이콘만 보이도록 변경
  - 모바일에서 필터 버튼을 아이콘만 보이도록 변경
  - 탭 버튼의 간격과 텍스트 크기를 화면 크기에 맞게 조정
  - 필터 사이드바 레이아웃 및 높이값 조정

## 📸 스크린샷(선택)

## 📚 참고사항
- 필터 사이드바 높이는 임의값으로 조정했습니다
