### PR TITLE
feat: add QNA create/edit API integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ dist-ssr
 *.sw?
 .history
 .env
+.env.local
 *storybook.log
 storybook-static
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,26 +9,33 @@ import {
   QnaListPage,
 } from '@/pages'
 
+import ProtectedRoute from './components/router/ProtectedRouter'
+
 import './App.css'
 
 function App() {
   return (
     <Routes>
       <Route element={<RootLayout />}>
+        {/* 비로그인 라우트 */}
         <Route
           path="/"
           element={<Navigate to={ROUTES_PATHS.QNA_LIST} replace />}
         />
         <Route path={ROUTES_PATHS.QNA_LIST} element={<QnaListPage />} />
         <Route path={ROUTES_PATHS.QNA_DETAIL} element={<QnaDetailPage />} />
-        <Route
-          path={ROUTES_PATHS.QNA_CREATE}
-          element={<QnACreatePage mode="create" />}
-        />
-        <Route
-          path={ROUTES_PATHS.QNA_EDIT}
-          element={<QnACreatePage mode="edit" />}
-        />
+
+        {/* 로그인 라우트 */}
+        <Route element={<ProtectedRoute />}>
+          <Route
+            path={ROUTES_PATHS.QNA_CREATE}
+            element={<QnACreatePage mode="create" />}
+          />
+          <Route
+            path={ROUTES_PATHS.QNA_EDIT}
+            element={<QnACreatePage mode="edit" />}
+          />
+        </Route>
         <Route
           path={ROUTES_PATHS.NOT_FOUND}
           element={<NotFoundPage type="notFound" />}

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -1,6 +1,6 @@
 import axios from 'axios'
 
-import { API_BASE_URL, MSW_BASE_URL } from '@/constants/apiPath'
+import { API_BASE_URL } from '@/constants/apiPath'
 
 export const api = axios.create({
   // 개발 환경에서는 MSW 가상 주소를 사용하고, 그 외에는 실제 API 주소를 사용한다.

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -4,11 +4,13 @@ import { API_BASE_URL, MSW_BASE_URL } from '@/constants/apiPath'
 
 export const api = axios.create({
   // 개발 환경에서는 MSW 가상 주소를 사용하고, 그 외에는 실제 API 주소를 사용한다.
-  baseURL: import.meta.env.DEV ? MSW_BASE_URL : API_BASE_URL,
+  // baseURL: import.meta.env.DEV ? MSW_BASE_URL : API_BASE_URL,
+  baseURL: API_BASE_URL,
   headers: {
     'Content-Type': 'application/json',
   },
 })
+
 // 응답 에러 공통 처리
 api.interceptors.response.use(
   (response) => response,
@@ -18,3 +20,15 @@ api.interceptors.response.use(
     return Promise.reject(error)
   }
 )
+
+/**
+ * 요청 인터셉터: accessToken 자동 첨부
+ * TODO: 로그인 구현 후 교체 예정
+ */
+api.interceptors.request.use((config) => {
+  const token = import.meta.env.VITE_TEST_TOKEN
+  if (token) {
+    config.headers.Authorization = `Bearer ${token}`
+  }
+  return config
+})

--- a/src/api/qna-api.ts
+++ b/src/api/qna-api.ts
@@ -6,6 +6,7 @@ import type {
   CreateAnswerResponse,
   CreateQuestionRequest,
   CreateQuestionResponse,
+  GetPresignedUrlResponse,
   GetQnaListParams,
   QnaQuestionDetail,
   UpdateQuestionRequest,
@@ -55,6 +56,23 @@ export const updateQuestion = async (
     `${QNA_API.questions}/${questionId}`,
     data
   )
+  return res.data
+}
+
+// S3에 직접 업로드 (presigned URL 사용)
+export const uploadImageToS3 = async (PresignedUrl: string, file: File) => {
+  await fetch(PresignedUrl, {
+    method: 'PUT',
+    body: file,
+    headers: { 'Content-Type': file.type },
+  })
+}
+
+// presignedUrl api호출
+export const getPresignedUrl = async (
+  fileName: string
+): Promise<GetPresignedUrlResponse> => {
+  const res = await api.put(QNA_API.presignedUrl, { file_name: fileName })
   return res.data
 }
 

--- a/src/components/common/markdown/EditorToolBar.tsx
+++ b/src/components/common/markdown/EditorToolBar.tsx
@@ -12,7 +12,15 @@ import {
   TextFormatGroup,
 } from './toolbar'
 
-export const EditorToolBar = ({ editor }: { editor: Editor | null }) => {
+type EditorToolBarProps = {
+  editor: Editor | null
+  onImageUpload?: (imgUrl: string) => void
+}
+
+export const EditorToolBar = ({
+  editor,
+  onImageUpload,
+}: EditorToolBarProps) => {
   if (!editor) return null
 
   return (
@@ -22,7 +30,7 @@ export const EditorToolBar = ({ editor }: { editor: Editor | null }) => {
         <HistoryGroup editor={editor} />
         <TextFormatGroup editor={editor} />
         <ColorGroup editor={editor} />
-        <MediaGroup editor={editor} />
+        <MediaGroup editor={editor} onImageUpload={onImageUpload} />
         {/* 모바일에선 숨김 */}
         <span className="hidden md:contents">
           <FontGroup editor={editor} />

--- a/src/components/common/markdown/TipTabEditor.tsx
+++ b/src/components/common/markdown/TipTabEditor.tsx
@@ -12,15 +12,22 @@ import Underline from '@tiptap/extension-underline'
 import { useEditor } from '@tiptap/react'
 import StarterKit from '@tiptap/starter-kit'
 
+import { getPresignedUrl, uploadImageToS3 } from '@/api'
+
 import { EditorToolBar } from './EditorToolBar'
 import { TextView } from './TextView'
 
 type EditorProps = {
   content: string
   contentChange: (Value?: string) => void
+  onImageUpload?: (imgUrl: string) => void
 }
 
-export default function TipTabEditor({ content, contentChange }: EditorProps) {
+export default function TipTabEditor({
+  content,
+  contentChange,
+  onImageUpload,
+}: EditorProps) {
   const [previewHtml, setPreviewHtml] = useState(content)
 
   const editor = useEditor({
@@ -38,22 +45,22 @@ export default function TipTabEditor({ content, contentChange }: EditorProps) {
         placeholder: '내용을 입력해 주세요.',
       }),
     ],
-    // 이미지 드래그로 이미지 url 변환
-    // TODO: API연동 후 교체 예정
+
     editorProps: {
       handleDrop(_view, event) {
         const file = event.dataTransfer?.files?.[0]
         if (!file || !file.type.startsWith('image/')) return false
 
-        const reader = new FileReader()
-        reader.onload = () => {
-          editor
-            ?.chain()
-            .focus()
-            .setImage({ src: reader.result as string })
-            .run()
-        }
-        reader.readAsDataURL(file)
+        void (async () => {
+          try {
+            const { presigned_url, img_url } = await getPresignedUrl(file.name)
+            await uploadImageToS3(presigned_url, file)
+            onImageUpload?.(img_url)
+            editor?.chain().focus().setImage({ src: img_url }).run()
+          } catch {
+            console.error('이미지 업로드 실패')
+          }
+        })()
 
         return true
       },
@@ -71,7 +78,7 @@ export default function TipTabEditor({ content, contentChange }: EditorProps) {
 
   return (
     <div>
-      <EditorToolBar editor={editor} />
+      <EditorToolBar editor={editor} onImageUpload={onImageUpload} />
       <TextView editor={editor} previewHtml={previewHtml} />
     </div>
   )

--- a/src/components/common/markdown/toolbar/groups/MediaGroup.tsx
+++ b/src/components/common/markdown/toolbar/groups/MediaGroup.tsx
@@ -3,16 +3,22 @@ import { useRef, useState } from 'react'
 import type { Editor } from '@tiptap/react'
 import { Image, Link2 } from 'lucide-react'
 
+import { getPresignedUrl, uploadImageToS3 } from '@/api'
 import { Popup } from '@/components'
 
 import { Group, IconBtn } from '../ToolbarPrimitives'
 
 type PopupState = {
-  type: 'link'
+  type: 'link' | 'image'
   isOpen: boolean
 }
 
-export default function MediaGroup({ editor }: { editor: Editor | null }) {
+type MediaGroupProp = {
+  editor: Editor | null
+  onImageUpload?: (imgUrl: string) => void
+}
+
+export default function MediaGroup({ editor, onImageUpload }: MediaGroupProp) {
   const [inputValue, setInputValue] = useState('')
   const [popup, setPopup] = useState<PopupState>({
     type: 'link',
@@ -48,23 +54,19 @@ export default function MediaGroup({ editor }: { editor: Editor | null }) {
     closePopup()
   }
 
-  // 파일 선택 시 Base64로 변환해서 에디터에 삽입
-  // API 연동 후 변경 예정
-  const handleImageFile = (e: React.ChangeEvent<HTMLInputElement>) => {
+  const handleImageFile = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0]
     if (!file || !file.type.startsWith('image/')) return
 
-    const reader = new FileReader()
-    reader.onload = () => {
-      editor
-        .chain()
-        .focus()
-        .setImage({ src: reader.result as string })
-        .run()
+    try {
+      const { presigned_url, img_url } = await getPresignedUrl(file.name)
+      await uploadImageToS3(presigned_url, file)
+      onImageUpload?.(img_url)
+      editor.chain().focus().setImage({ src: img_url }).run()
+    } catch {
+      setPopup({ type: 'image', isOpen: true })
     }
-    reader.readAsDataURL(file)
 
-    // 같은 파일 재선택 가능하도록 초기화
     e.target.value = ''
   }
 

--- a/src/components/router/ProtectedRouter.tsx
+++ b/src/components/router/ProtectedRouter.tsx
@@ -1,0 +1,10 @@
+import { Navigate, Outlet } from 'react-router'
+
+import { ROUTES_PATHS } from '@/constants/url'
+import { useAuthStore } from '@/store'
+
+export default function ProtectedRoute() {
+  const accessToken = useAuthStore((s) => s.accessToken)
+  if (!accessToken) return <Navigate to={ROUTES_PATHS.LOGIN} replace />
+  return <Outlet />
+}

--- a/src/constants/message.ts
+++ b/src/constants/message.ts
@@ -1,0 +1,10 @@
+// constants/messages.ts
+export const ERROR_MESSAGES = {
+  // validation
+  CATEGORY_REQUIRED: '카테고리를 선택해 주세요.',
+  TITLE_REQUIRED: '제목을 입력해 주세요.',
+  CONTENT_REQUIRED: '질문 내용을 입력해 주세요.',
+  // API 에러
+  CREATE_QUESTION: '질문 등록에 실패했습니다. 다시 시도해 주세요.',
+  UPDATE_QUESTION: '질문 수정에 실패했습니다. 다시 시도해 주세요.',
+} as const

--- a/src/constants/qna.ts
+++ b/src/constants/qna.ts
@@ -1,4 +1,5 @@
 export const QNA_API = {
-  categories: '/qna/categories',
-  questions: '/qna/questions',
+  categories: '/qna/categories/',
+  questions: '/qna/questions/',
+  presignedUrl: '/qna/questions/presigned-url',
 } as const

--- a/src/constants/url.ts
+++ b/src/constants/url.ts
@@ -1,4 +1,6 @@
 export const ROUTES_PATHS = {
+  LOGIN: '/login',
+
   QNA_LIST: '/questions',
   QNA_DETAIL: `/questions/:id`,
   QNA_CREATE: '/questions/new',

--- a/src/hooks/useQnaForm.ts
+++ b/src/hooks/useQnaForm.ts
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from 'react'
 import { useNavigate } from 'react-router'
 
+import { ERROR_MESSAGES } from '@/constants/message'
 import { ROUTES_PATHS } from '@/constants/url'
 import {
   useCategoriesQuery,
@@ -16,6 +17,7 @@ export function useQnaForm(mode: 'create' | 'edit', questionId?: number) {
   const [content, setContent] = useState('')
   const [selectedCategory, setSelectedCategory] =
     useState<SelectedCategory | null>(null)
+  const [imageUrls, setImageUrls] = useState<string[]>([])
   const [popupMessage, setPopupMessage] = useState<string | null>(null)
 
   const navigate = useNavigate()
@@ -74,10 +76,10 @@ export function useQnaForm(mode: 'create' | 'edit', questionId?: number) {
    * @returns 에러 메시지 문자열 | 통과 시 null
    */
   const validate = (): string | null => {
-    if (!categoryId) return '카테고리를 선택해 주세요.'
-    if (!title.trim()) return '제목을 입력해 주세요.'
+    if (!categoryId) return ERROR_MESSAGES.CATEGORY_REQUIRED
+    if (!title.trim()) return ERROR_MESSAGES.TITLE_REQUIRED
     if (!content.trim() || content === '<p></p>' || content === '<p><br></p>')
-      return '질문 내용을 입력해 주세요.'
+      return ERROR_MESSAGES.CONTENT_REQUIRED
     return null
   }
 
@@ -93,16 +95,31 @@ export function useQnaForm(mode: 'create' | 'edit', questionId?: number) {
 
     if (mode === 'create') {
       createQuestion(
-        { title, content, category: categoryId! },
-        { onSuccess: () => navigate(ROUTES_PATHS.QNA_LIST) }
+        { title, content, category_id: categoryId! },
+        {
+          onSuccess: () => navigate(ROUTES_PATHS.QNA_LIST),
+          onError: () => setPopupMessage(ERROR_MESSAGES.CREATE_QUESTION),
+        }
       )
     } else {
       updateQuestion(
-        { title, content, category: categoryId! },
-        { onSuccess: () => navigate(ROUTES_PATHS.QNA_DETAIL_URL(questionId!)) }
+        { title, content, category_id: categoryId! },
+        {
+          onSuccess: () => navigate(ROUTES_PATHS.QNA_DETAIL_URL(questionId!)),
+          onError: () => setPopupMessage(ERROR_MESSAGES.UPDATE_QUESTION),
+        }
       )
     }
   }
+
+  /**
+   * 이미지 업로드 완료 후 URL을 imageUrls 상태에 추가
+   * - 질문 등록/수정 시 image_urls 필드에 포함됨
+   */
+  const handleImageUpload = (imgUrl: string) => {
+    setImageUrls((prev) => [...prev, imgUrl])
+  }
+
   return {
     // 상태
     title,
@@ -111,6 +128,7 @@ export function useQnaForm(mode: 'create' | 'edit', questionId?: number) {
     setContent,
     popupMessage,
     setPopupMessage,
+    imageUrls,
     // 데이터
     categories,
     questionDetail,
@@ -120,5 +138,6 @@ export function useQnaForm(mode: 'create' | 'edit', questionId?: number) {
     // 핸들러
     handleSubmit,
     handleCategorySelect: setSelectedCategory,
+    handleImageUpload,
   }
 }

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -13,7 +13,7 @@ export const handlers = [
   }),
   ...chatMessageHandlers,
   ...chatSessionHandlers,
-  ...qnaCategoryHandlers,
+  // ...qnaCategoryHandlers,
   ...qnaListHandlers,
   ...qnaDetailHandlers,
   ...qnaCreateHandlers,

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -2,7 +2,6 @@ import { http, HttpResponse } from 'msw'
 
 import { chatMessageHandlers } from './handlers/chatMessageHandler'
 import { chatSessionHandlers } from './handlers/chatSessionHandler'
-import { qnaCategoryHandlers } from './handlers/qnaCategoryHandler'
 import { qnaCreateHandlers } from './handlers/qnaCreateHandler'
 import { qnaDetailHandlers } from './handlers/qnaDetailHandler'
 import { qnaListHandlers } from './handlers/qnaListHandler'

--- a/src/mocks/handlers/qnaCategoryHandler.ts
+++ b/src/mocks/handlers/qnaCategoryHandler.ts
@@ -1,14 +1,15 @@
 import { http, HttpResponse } from 'msw'
 
-import { toMswApiUrl } from '@/constants/apiPath'
+import { API_BASE_URL, toMswApiUrl } from '@/constants/apiPath'
 import { QNA_API } from '@/constants/qna'
 import { mockCategories } from '@/mocks/data/category-mock'
 
 // 카테고리 목록 조회 API
+// 카테고리 목록 조회 API - 백엔드 미구현으로 임시 MSW 사용
 export const qnaCategoryHandlers = [
-  http.get(toMswApiUrl(QNA_API.categories), () => {
-    return HttpResponse.json({
-      categories: mockCategories,
-    })
-  }),
+  // http.get(`${API_BASE_URL}${QNA_API.categories}`, () => {
+  //   return HttpResponse.json({
+  //     categories: mockCategories,
+  //   })
+  // }),
 ]

--- a/src/mocks/handlers/qnaCategoryHandler.ts
+++ b/src/mocks/handlers/qnaCategoryHandler.ts
@@ -1,9 +1,3 @@
-import { http, HttpResponse } from 'msw'
-
-import { API_BASE_URL, toMswApiUrl } from '@/constants/apiPath'
-import { QNA_API } from '@/constants/qna'
-import { mockCategories } from '@/mocks/data/category-mock'
-
 // 카테고리 목록 조회 API
 // 카테고리 목록 조회 API - 백엔드 미구현으로 임시 MSW 사용
 export const qnaCategoryHandlers = [

--- a/src/pages/qna-create/QnaCreatePage.tsx
+++ b/src/pages/qna-create/QnaCreatePage.tsx
@@ -24,9 +24,9 @@ export default function QnACreatePage({ mode }: QnACreatePageProps) {
     questionDetail,
     initialCategory,
     isPending,
-    isError,
     handleSubmit,
     handleCategorySelect,
+    handleImageUpload,
   } = useQnaForm(mode, questionId)
 
   if (isPending) return <Loading />
@@ -63,6 +63,7 @@ export default function QnACreatePage({ mode }: QnACreatePageProps) {
               key={questionDetail?.id ?? 'create'}
               content={content}
               contentChange={(value) => setContent(value ?? '')}
+              onImageUpload={handleImageUpload}
             />
           )}
         </div>
@@ -79,7 +80,7 @@ export default function QnACreatePage({ mode }: QnACreatePageProps) {
         </Button>
       </div>
       <Popup
-        isOpen={!!popupMessage || isError}
+        isOpen={!!popupMessage}
         content={popupMessage}
         confirmLabel="확인"
         onConfirm={() => setPopupMessage(null)}

--- a/src/types/api-response/qna.ts
+++ b/src/types/api-response/qna.ts
@@ -1,4 +1,4 @@
-import type { QnaImage, QnaQuestionDetail } from './detail'
+import type { QnaQuestionDetail } from './detail'
 
 // 질문 목록 조회 시 사용하는 답변 상태 query 값
 export type AnswerStatus = 'answered' | 'waiting'
@@ -15,10 +15,10 @@ export type GetQnaListParams = {
 
 // 질문 등록 API 요청 본문 타입
 export type CreateQuestionRequest = {
-  title: QnaQuestionDetail['title']
-  content: QnaQuestionDetail['content']
-  category: number
-  image_ids?: QnaImage['id'][]
+  category_id: number
+  title: string
+  content: string
+  image_urls?: string[]
 }
 
 // 답변 등록 API 요청 본문 타입
@@ -38,3 +38,13 @@ export type CreateQuestionResponse = QnaQuestionDetail
 export type UpdateQuestionRequest = Partial<CreateQuestionRequest>
 
 export type UpdateQuestionResponse = QnaQuestionDetail
+
+export type GetPresignedUrlRequest = {
+  file_name: string
+}
+
+export type GetPresignedUrlResponse = {
+  presigned_url: string
+  img_url: string
+  key: string
+}


### PR DESCRIPTION
## 📌 관련 이슈

Closes #94 

## ✨ 변경 내용

- ProtectedRoute 컴포넌트 구현 및 질문 등록/수정 페이지 인증 가드 적용
- api.ts 요청 인터셉터 accessToken 자동 첨부 추가
- presigned URL 방식 이미지 업로드 구현 (파일 선택 / 드래그앤드롭)
- EditorToolBar, TipTabEditor, MediaGroup에 onImageUpload prop 추가
- useQnaForm, QnaCreatePage에 imageUrls 상태 및 핸들러 추가
- qna 타입 Swagger 스펙에 맞게 수정
- 에러 팝업 메시지 상수화 (message.ts)

## 📸 스크린샷

https://github.com/user-attachments/assets/caf5f88e-b684-474c-8885-3999ba356fc3


## 📚 참고사항

- 카테고리 API 실제 연결로 MSW 핸들러 주석 처리
- baseURL을 `MSW_BASE_URL` → `API_BASE_URL`로 변경
- API 명세서와 Swagger 스키마가 달라 백엔드에 확인 요청한 상태
  - 실제 테스트 결과 Swagger 스키마 기준으로 등록이 정상 동작하는 것 확인
  - 백엔드 답변 후 필요 시 타입 수정 예정