### PR TITLE
refactor: add FontSize extension to tiptap editor

### DIFF
--- a/src/api/qna-api.ts
+++ b/src/api/qna-api.ts
@@ -17,7 +17,7 @@ import { api } from './api'
 
 // 카테고리 조회 api 호출
 export const getCategories = async (): Promise<CategoryResponse> => {
-  const res = await api.get<CategoryResponse>(`${QNA_API.categories}/`)
+  const res = await api.get<CategoryResponse>(`${QNA_API.categories}`)
   return res.data
 }
 
@@ -25,7 +25,7 @@ export const getCategories = async (): Promise<CategoryResponse> => {
 export const getQnaList = async (
   params?: GetQnaListParams
 ): Promise<QnaListResponse> => {
-  const res = await api.get<QnaListResponse>(`${QNA_API.questions}/`, {
+  const res = await api.get<QnaListResponse>(`${QNA_API.questions}`, {
     params,
   })
   return res.data

--- a/src/components/common/markdown/TipTabEditor.tsx
+++ b/src/components/common/markdown/TipTabEditor.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 
 import Color from '@tiptap/extension-color'
 import FontFamily from '@tiptap/extension-font-family'
@@ -13,6 +13,7 @@ import { useEditor } from '@tiptap/react'
 import StarterKit from '@tiptap/starter-kit'
 
 import { getPresignedUrl, uploadImageToS3 } from '@/api'
+import { FontSize } from '@/components/common/markdown/extentions/FontSize'
 
 import { EditorToolBar } from './EditorToolBar'
 import { TextView } from './TextView'
@@ -38,6 +39,7 @@ export default function TipTabEditor({
       Image,
       TextAlign.configure({ types: ['heading', 'paragraph'] }),
       TextStyle,
+      FontSize,
       Color,
       FontFamily,
       Highlight.configure({ multicolor: true }),

--- a/src/components/common/markdown/TipTabEditor.tsx
+++ b/src/components/common/markdown/TipTabEditor.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
 
 import Color from '@tiptap/extension-color'
 import FontFamily from '@tiptap/extension-font-family'

--- a/src/components/common/markdown/extentions/FontSize.ts
+++ b/src/components/common/markdown/extentions/FontSize.ts
@@ -5,7 +5,7 @@ declare module '@tiptap/core' {
   // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
   interface Commands<ReturnType> {
     fontSize: {
-      setFontsize: (size: string) => ReturnType
+      setFontSize: (size: string) => ReturnType
       unsetFontSize: () => ReturnType
     }
   }
@@ -13,9 +13,11 @@ declare module '@tiptap/core' {
 
 export const FontSize = Extension.create({
   name: 'fontSize',
+
   addOptions() {
-    return { type: ['textStyle'] }
+    return { types: ['textStyle'] }
   },
+
   addGlobalAttributes() {
     return [
       {
@@ -23,7 +25,7 @@ export const FontSize = Extension.create({
         attributes: {
           fontSize: {
             default: null,
-            parseHTML: (e1) => e1.style.fontSize || null,
+            parseHTML: (el) => el.style.fontSize || null,
             renderHTML: (attrs) => {
               if (!attrs.fontSize) return {}
               return { style: `font-size: ${attrs.fontSize}` }
@@ -33,12 +35,14 @@ export const FontSize = Extension.create({
       },
     ]
   },
+
   addCommands() {
     return {
-      setFontsize:
-        (fontSize) =>
+      setFontSize:
+        (fontSize: string) =>
         ({ chain }) =>
           chain().setMark('textStyle', { fontSize }).run(),
+
       unsetFontSize:
         () =>
         ({ chain }) =>

--- a/src/components/common/markdown/toolbar/groups/FontGroup.tsx
+++ b/src/components/common/markdown/toolbar/groups/FontGroup.tsx
@@ -4,6 +4,8 @@ import { cn } from '@/utils'
 
 import { Group } from '../ToolbarPrimitives'
 
+import '@/components/common/markdown/extentions/FontSize'
+
 const FONT_FAMILIES = [
   { label: '기본서체', value: '' },
   { label: 'Pretendard', value: 'Pretendard, sans-serif' },
@@ -49,7 +51,7 @@ export default function FontGroup({ editor }: { editor: Editor | null }) {
   }
 
   const handleFontSizeChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
-    editor.chain().focus().setFontsize(`${e.target.value}px`).run()
+    editor.chain().focus().setFontSize(`${e.target.value}px`).run()
   }
 
   return (

--- a/src/features/qna-list/components/QnaCard.tsx
+++ b/src/features/qna-list/components/QnaCard.tsx
@@ -4,6 +4,7 @@ import { AnswerBadge, Avatar, CategoryPath } from '@/components'
 import { ROUTES_PATHS } from '@/constants/url'
 import type { QnaListItem } from '@/features/qna-list'
 import { cn, formatTimeAgo } from '@/utils'
+import { removeHtmlTags } from '@/utils/string'
 
 type QnaCardProps = {
   question: QnaListItem
@@ -51,7 +52,7 @@ export default function QnaCard({ question, keyword }: QnaCardProps) {
         </h3>
 
         <p className="text-text-light mt-5 line-clamp-2 text-sm">
-          {highlightText(question.content_preview, keyword)}
+          {highlightText(removeHtmlTags(question.content_preview), keyword)}
         </p>
 
         <div className="mt-5 flex items-center justify-between text-sm md:mt-auto">

--- a/src/utils/string.ts
+++ b/src/utils/string.ts
@@ -1,0 +1,3 @@
+export const removeHtmlTags = (html: string) => {
+  return html.replace(/<[^>]*>/g, '').trim()
+}


### PR DESCRIPTION
## 📌 관련 이슈

Closes #104 

## ✨ 변경 내용

- HTML 태그 제거 유틸 함수(removeHtmlTags) 추가
- QnaCard에서 content_preview에 적용하여 highlightText와 함께 사용하도록 수정
- qna API 경로에 불필요하게 중복된 슬래시(/) 제거
- TipTapEditor에 FontSize extension 추가
- FontSize 타입 에러 및 setFontSize 오타 수정
- 잘못된 import 경로 수정

## 📸 스크린샷

https://github.com/user-attachments/assets/739f4200-5e9e-44c9-80c6-03b917081c4d

## 📚 참고사항
