### PR TITLE
fix: defer category api call until filter sidebar opens 

### DIFF
--- a/src/features/qna-list/components/FilterSidebar.tsx
+++ b/src/features/qna-list/components/FilterSidebar.tsx
@@ -47,7 +47,11 @@ export default function FilterSidebar({
   isAppliedCategory,
   onCategoryFilterApply,
 }: FilterSidebarProps) {
-  const { data: categories = [], isPending, isError } = useCategoriesQuery()
+  const {
+    data: categories = [],
+    isPending,
+    isError,
+  } = useCategoriesQuery(isFilterOpen)
 
   const appliedSelection = useMemo(
     () => findSelectedCategory(categories, isAppliedCategory),

--- a/src/queries/useCategoriesQuery.ts
+++ b/src/queries/useCategoriesQuery.ts
@@ -2,11 +2,12 @@ import { useQuery } from '@tanstack/react-query'
 
 import { getCategories } from '@/api'
 
-export default function useCategoriesQuery() {
+export default function useCategoriesQuery(enabled?: boolean) {
   return useQuery({
     queryKey: ['qna-categories'],
     queryFn: getCategories,
     // 컴포넌트에서는 응답 객체 전체 대신 실제로 필요한 categories 배열만 다룬다.
     select: (data) => data.categories,
+    enabled: enabled ?? true,
   })
 }


### PR DESCRIPTION
## 📌 관련 이슈

Closes #114

## ✨ 변경 내용

- useCategoriesQuery에 enabled 옵션 파라미터 추가 (optional, 기본값 true)
- FilterSidebar에서 isFilterOpen 값을 enabled로 전달

## 📸 스크린샷

| Before | After |
|---|---|
| <img width="400" alt="before" src="https://github.com/user-attachments/assets/462e718b-f106-48ee-9bde-27d840b06525" /> | <img width="400" alt="after2" src="https://github.com/user-attachments/assets/b4e2eec9-aabc-4ba5-baee-ab939c1c8172" /><img width="400" alt="after1" src="https://github.com/user-attachments/assets/f24e2e61-917f-4473-930c-a3ae77e28439" />  |

## 📚 참고사항
