### PR TITLE
fix: persist AI answer state with react-query and zustand 

### DIFF
--- a/src/features/chat-widget/components/AiAnswerCard.tsx
+++ b/src/features/chat-widget/components/AiAnswerCard.tsx
@@ -11,8 +11,10 @@ import {
   getStoredAiAnswer,
   setStoredAiAnswer,
 } from '@/features/chat-widget/lib/aiAnswerStorage'
+import { useToast } from '@/hooks/useToast'
 import { useAiAnswerQuery, useCreateAiAnswerMutation } from '@/queries'
-import { useAiAnswerUiStore } from '@/store'
+import { useAiAnswerUiStore, useAuthStore } from '@/store'
+import { useModalStore } from '@/store/useModalStore'
 import type { QnaAiAnswer, QnaQuestionDetail } from '@/types'
 
 import BubbleTail from './BubbleTail'
@@ -27,10 +29,13 @@ const COLLAPSED_ANSWER_HEIGHT = 320
 
 export default function AiAnswerCard({ question }: AiAnswerCardProps) {
   const { chat } = useChatWidgetContext()
+  const isEnrolled = useAuthStore((state) => state.isEnrolled())
+  const openUnauthorized = useModalStore((state) => state.openUnauthorized)
   const openByQuestionId = useAiAnswerUiStore((state) => state.openByQuestionId)
   const openDetail = useAiAnswerUiStore((state) => state.openDetail)
   const closeDetail = useAiAnswerUiStore((state) => state.closeDetail)
   const { mutateAsync, isPending } = useCreateAiAnswerMutation()
+  const { error: showErrorToast } = useToast()
   const initialAiAnswer = question.ai_answer ?? getStoredAiAnswer(question.id)
   const [createdAiAnswer, setCreatedAiAnswer] = useState<QnaAiAnswer | null>(
     initialAiAnswer
@@ -73,6 +78,11 @@ export default function AiAnswerCard({ question }: AiAnswerCardProps) {
   }, [aiAnswer, openDetail, question.id])
 
   const handleToggleDetail = async () => {
+    if (!isEnrolled) {
+      openUnauthorized()
+      return
+    }
+
     if (isFetching || isPending) {
       return
     }
@@ -87,67 +97,84 @@ export default function AiAnswerCard({ question }: AiAnswerCardProps) {
       return
     }
 
-    try {
-      const result = await refetch()
+    // refetch는 reject 대신 result.status/result.error로 결과를 반환한다.
+    const result = await refetch()
 
-      if (result.data) {
+    if (result.status === 'success' && result.data) {
+      openDetail(question.id)
+      return
+    }
+
+    if (result.status !== 'error') {
+      return
+    }
+
+    const lookupError = result.error
+    const errorDetail = axios.isAxiosError(lookupError)
+      ? lookupError.response?.data?.error_detail
+      : undefined
+    const status = axios.isAxiosError(lookupError)
+      ? lookupError.response?.status
+      : null
+
+    if (axios.isAxiosError(lookupError)) {
+      console.error('AI answer lookup failed', {
+        method: 'GET',
+        url: lookupError.config?.url,
+        status: lookupError.response?.status,
+        data: lookupError.response?.data,
+      })
+    }
+
+    if (status === 404) {
+      try {
+        const nextAiAnswer = await mutateAsync(question.id)
+
+        setCreatedAiAnswer(nextAiAnswer)
+        setStoredAiAnswer(nextAiAnswer)
         openDetail(question.id)
-      }
-    } catch (error) {
-      const errorDetail = axios.isAxiosError(error)
-        ? error.response?.data?.error_detail
-        : undefined
-      const status = axios.isAxiosError(error) ? error.response?.status : null
+        return
+      } catch (createError) {
+        const createErrorDetail = axios.isAxiosError(createError)
+          ? createError.response?.data?.error_detail
+          : undefined
 
-      if (axios.isAxiosError(error)) {
-        console.error('AI answer lookup failed', {
-          method: 'GET',
-          url: error.config?.url,
-          status: error.response?.status,
-          data: error.response?.data,
-        })
-      }
-
-      if (status === 404) {
-        try {
-          const nextAiAnswer = await mutateAsync(question.id)
-
-          setCreatedAiAnswer(nextAiAnswer)
-          setStoredAiAnswer(nextAiAnswer)
-          openDetail(question.id)
-          return
-        } catch (createError) {
-          const createErrorDetail = axios.isAxiosError(createError)
-            ? createError.response?.data?.error_detail
-            : undefined
-
-          if (axios.isAxiosError(createError)) {
-            console.error('AI answer creation failed', {
-              method: 'GET',
-              url: createError.config?.url,
-              status: createError.response?.status,
-              data: createError.response?.data,
-            })
-          }
-
-          alert(
-            createErrorDetail ??
-              'AI 답변 생성에 실패했습니다. 다시 시도해주세요.'
-          )
-          return
+        if (axios.isAxiosError(createError)) {
+          console.error('AI answer creation failed', {
+            method: 'GET',
+            url: createError.config?.url,
+            status: createError.response?.status,
+            data: createError.response?.data,
+          })
         }
-      }
 
-      if (status === 409) {
-        alert(errorDetail ?? '이미 AI가 답변을 생성했습니다.')
+        showErrorToast(
+          createErrorDetail ??
+            'AI 답변을 불러오지 못했습니다. 다시 시도해주세요.'
+        )
         return
       }
-
-      alert(errorDetail ?? 'AI 답변 생성에 실패했습니다. 다시 시도해주세요.')
     }
+
+    if (status === 409) {
+      console.warn('AI answer already exists', {
+        questionId: question.id,
+        errorDetail,
+      })
+      return
+    }
+
+    showErrorToast(
+      errorDetail ?? 'AI 답변을 불러오지 못했습니다. 다시 시도해주세요.'
+    )
   }
 
   const handleOpenChat = () => {
+    if (!isEnrolled) {
+      openUnauthorized()
+      return
+    }
+
     if (!aiAnswer) {
       return
     }

--- a/src/features/chat-widget/components/AiAnswerCard.tsx
+++ b/src/features/chat-widget/components/AiAnswerCard.tsx
@@ -1,14 +1,18 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 
 import axios from 'axios'
 import { ChevronDown } from 'lucide-react'
 
-import { getAiAnswer } from '@/api'
 import { Button, Loading } from '@/components'
 import AiMarkdownRenderer from '@/components/common/markdown/AiMarkdownRenderer'
 import { useChatWidgetContext } from '@/features/chat-widget/hooks/useChatWidgetContext'
 import useExpandableContent from '@/features/chat-widget/hooks/useExpandableContent'
-import { useCreateAiAnswerMutation } from '@/queries'
+import {
+  getStoredAiAnswer,
+  setStoredAiAnswer,
+} from '@/features/chat-widget/lib/aiAnswerStorage'
+import { useAiAnswerQuery, useCreateAiAnswerMutation } from '@/queries'
+import { useAiAnswerUiStore } from '@/store'
 import type { QnaAiAnswer, QnaQuestionDetail } from '@/types'
 
 import BubbleTail from './BubbleTail'
@@ -22,9 +26,32 @@ type AiAnswerCardProps = {
 const COLLAPSED_ANSWER_HEIGHT = 320
 
 export default function AiAnswerCard({ question }: AiAnswerCardProps) {
-  const { chat, detail } = useChatWidgetContext()
+  const { chat } = useChatWidgetContext()
+  const openByQuestionId = useAiAnswerUiStore((state) => state.openByQuestionId)
+  const openDetail = useAiAnswerUiStore((state) => state.openDetail)
+  const closeDetail = useAiAnswerUiStore((state) => state.closeDetail)
   const { mutateAsync, isPending } = useCreateAiAnswerMutation()
-  const [aiAnswer, setAiAnswer] = useState<QnaAiAnswer | null>(null)
+  const initialAiAnswer = question.ai_answer ?? getStoredAiAnswer(question.id)
+  const [createdAiAnswer, setCreatedAiAnswer] = useState<QnaAiAnswer | null>(
+    initialAiAnswer
+  )
+  const {
+    data: queriedAiAnswer,
+    refetch,
+    isFetching,
+  } = useAiAnswerQuery({
+    questionId: question.id,
+    initialData: initialAiAnswer,
+  })
+  const aiAnswer = queriedAiAnswer ?? createdAiAnswer
+  const isOpen = Boolean(aiAnswer) && (openByQuestionId[question.id] ?? true)
+  // TODO: 질문 수정 기준 업데이트 시간 변경 후 주석 해제
+  // const shouldShowOutdatedNotice =
+  //   question.updated_at != null &&
+  //   aiAnswer?.created_at != null &&
+  //   new Date(question.updated_at).getTime() >
+  //     new Date(aiAnswer.created_at).getTime()
+  const shouldShowOutdatedNotice = false
 
   const {
     contentRef: answerContentRef,
@@ -34,29 +61,38 @@ export default function AiAnswerCard({ question }: AiAnswerCardProps) {
   } = useExpandableContent({
     content: aiAnswer?.output,
     collapsedHeightPx: COLLAPSED_ANSWER_HEIGHT,
-    enabled: detail.isOpen,
+    enabled: isOpen,
   })
 
-  const handleToggleDetail = async () => {
-    if (isPending) {
+  useEffect(() => {
+    if (!aiAnswer) {
       return
     }
 
-    if (detail.isOpen) {
-      detail.close()
+    openDetail(question.id)
+  }, [aiAnswer, openDetail, question.id])
+
+  const handleToggleDetail = async () => {
+    if (isFetching || isPending) {
+      return
+    }
+
+    if (isOpen) {
+      closeDetail(question.id)
       return
     }
 
     if (aiAnswer) {
-      detail.open()
+      openDetail(question.id)
       return
     }
 
     try {
-      const existingAiAnswer = await getAiAnswer(question.id)
+      const result = await refetch()
 
-      setAiAnswer(existingAiAnswer)
-      detail.open()
+      if (result.data) {
+        openDetail(question.id)
+      }
     } catch (error) {
       const errorDetail = axios.isAxiosError(error)
         ? error.response?.data?.error_detail
@@ -74,10 +110,11 @@ export default function AiAnswerCard({ question }: AiAnswerCardProps) {
 
       if (status === 404) {
         try {
-          const createdAiAnswer = await mutateAsync(question.id)
+          const nextAiAnswer = await mutateAsync(question.id)
 
-          setAiAnswer(createdAiAnswer)
-          detail.open()
+          setCreatedAiAnswer(nextAiAnswer)
+          setStoredAiAnswer(nextAiAnswer)
+          openDetail(question.id)
           return
         } catch (createError) {
           const createErrorDetail = axios.isAxiosError(createError)
@@ -129,7 +166,7 @@ export default function AiAnswerCard({ question }: AiAnswerCardProps) {
     <div className="my-8 flex w-full flex-col items-stretch gap-4 md:my-11 md:flex-row md:items-start md:gap-8">
       <ChatBadge size="lg" className="hidden md:flex md:h-15 md:w-15" />
 
-      {!detail.isOpen ? (
+      {!isOpen ? (
         <div className="shadow-box relative w-full min-w-0 flex-1 rounded-xl bg-white px-5 pt-4 pb-5 sm:px-6 sm:pt-5.25 sm:pb-6.75 md:max-w-178.5">
           {/* 말풍선 꼬리  */}
           <BubbleTail color="#fff" className="hidden md:block" />
@@ -142,7 +179,7 @@ export default function AiAnswerCard({ question }: AiAnswerCardProps) {
               variant="text"
               type="button"
               onClick={handleToggleDetail}
-              disabled={isPending}
+              disabled={isFetching || isPending}
               className="text-text-sub disabled:text-text-sub gap-2 px-0 text-left font-bold hover:bg-transparent disabled:bg-transparent"
             >
               <span>질문에 대한</span>
@@ -150,7 +187,7 @@ export default function AiAnswerCard({ question }: AiAnswerCardProps) {
                 <ChatBadge size="xs" />
                 <span className="text-gradient-brand">AI OZ</span>
               </span>
-              {isPending ? (
+              {isFetching || isPending ? (
                 <span className="inline-flex items-center gap-2">
                   <span>의 답변 생성 중</span>
                   <span className="scale-75">
@@ -167,8 +204,7 @@ export default function AiAnswerCard({ question }: AiAnswerCardProps) {
           </div>
         </div>
       ) : (
-        /* 답변보기 카드 */
-        <div className="shadow-box bg-primary-100/40 relative max-w-full flex-1 rounded-xl p-5 sm:p-6 md:max-w-178.5 md:p-8">
+        <div className="shadow-box bg-primary-100/40 relative min-w-0 flex-1 rounded-xl p-5 sm:p-6 md:p-8">
           {/* 말풍선 꼬리  */}
           <BubbleTail color="#f9f5fa" className="hidden md:block" />
 
@@ -176,6 +212,11 @@ export default function AiAnswerCard({ question }: AiAnswerCardProps) {
             <div className="flex items-center gap-1.5">
               <ChatBadge size="xs" />
               <span className="text-gradient-brand">AI OZ</span>
+              {shouldShowOutdatedNotice && (
+                <span className="text-primary-500 text-xs font-semibold">
+                  수정 전 질문 기준 답변입니다.
+                </span>
+              )}
             </div>
             {aiAnswer?.output && (
               <div className="mb-1">

--- a/src/features/chat-widget/components/ChatBadge.tsx
+++ b/src/features/chat-widget/components/ChatBadge.tsx
@@ -15,7 +15,7 @@ const iconSizeMap = {
   lg: 'lg', // 60 → 40
 } as const
 
-export default function ChatBadge({ size = 'md' }: ChatBadgeProps) {
+export default function ChatBadge({ size = 'md', className }: ChatBadgeProps) {
   return (
     <div
       className={cn(
@@ -23,7 +23,8 @@ export default function ChatBadge({ size = 'md' }: ChatBadgeProps) {
         size === 'xs' && 'h-6 w-6', // 24
         size === 'sm' && 'h-8 w-8', // 32
         size === 'md' && 'h-10 w-10', // 40
-        size === 'lg' && 'h-15 w-15' // 60
+        size === 'lg' && 'h-15 w-15', // 60
+        className
       )}
     >
       <Avatar src={chatBotIcon} size={iconSizeMap[size]} alt="AI OZ" />

--- a/src/features/chat-widget/context/ChatWidgetContext.ts
+++ b/src/features/chat-widget/context/ChatWidgetContext.ts
@@ -25,7 +25,6 @@ type ChatState = ToggleState & {
 // 전체 UI 상태 Context 타입
 export type ChatWidgetContextValue = {
   chat: ChatState
-  detail: ToggleState
 }
 
 export const ChatWidgetContext = createContext<ChatWidgetContextValue | null>(

--- a/src/features/chat-widget/lib/aiAnswerStorage.ts
+++ b/src/features/chat-widget/lib/aiAnswerStorage.ts
@@ -1,0 +1,30 @@
+import type { QnaAiAnswer } from '@/types'
+
+// 임시용 AI 답변 로컬 저장소 유틸입니다.
+// 상세 API 응답에 ai_answer가 없거나 새로고침 전 상태를 유지해야 할 때 사용합니다.
+const AI_ANSWER_STORAGE_KEY = 'qna-ai-answer'
+
+const getStorageKey = (questionId: number) =>
+  `${AI_ANSWER_STORAGE_KEY}:${questionId}`
+
+// questionId 기준으로 저장된 AI 답변을 조회합니다.
+export const getStoredAiAnswer = (questionId: number): QnaAiAnswer | null => {
+  try {
+    const value = localStorage.getItem(getStorageKey(questionId))
+    return value ? (JSON.parse(value) as QnaAiAnswer) : null
+  } catch {
+    return null
+  }
+}
+
+// 생성되거나 조회한 AI 답변을 questionId 기준으로 저장합니다.
+export const setStoredAiAnswer = (aiAnswer: QnaAiAnswer) => {
+  try {
+    localStorage.setItem(
+      getStorageKey(aiAnswer.question_id),
+      JSON.stringify(aiAnswer)
+    )
+  } catch {
+    // localStorage 사용 불가 시 무시
+  }
+}

--- a/src/queries/index.ts
+++ b/src/queries/index.ts
@@ -1,4 +1,5 @@
 export { default as useAdoptAnswerMutation } from './useAdoptAnswerMutation'
+export { default as useAiAnswerQuery } from './useAiAnswerQuery'
 export { default as useCategoriesQuery } from './useCategoriesQuery'
 export { default as useCreateAiAnswerMutation } from './useCreateAiAnswerMutation'
 export { default as useCreateAnswerCommentMutation } from './useCreateAnswerCommentMutation'

--- a/src/queries/useAiAnswerQuery.ts
+++ b/src/queries/useAiAnswerQuery.ts
@@ -1,5 +1,3 @@
-import { useEffect } from 'react'
-
 import { useQuery } from '@tanstack/react-query'
 
 import { getAiAnswer } from '@/api'
@@ -19,22 +17,17 @@ export default function useAiAnswerQuery({
 }: UseAiAnswerQueryOptions) {
   const query = useQuery({
     queryKey: ['qna-ai-answer', questionId],
-    queryFn: () => getAiAnswer(questionId),
+    queryFn: async () => {
+      const aiAnswer = await getAiAnswer(questionId)
+      setStoredAiAnswer(aiAnswer)
+      return aiAnswer
+    },
     // 답변 카드 열기 전에는 요청하지 않습니다.
     enabled: false,
     retry: false,
     staleTime: Infinity,
-    ...(initialData ? { initialData } : {}),
+    ...(initialData ? { placeholderData: initialData } : {}),
   })
-
-  useEffect(() => {
-    if (!query.data) {
-      return
-    }
-
-    // 조회한 답변은 로컬에도 저장해 상세 재진입 시 재사용합니다.
-    setStoredAiAnswer(query.data)
-  }, [query.data])
 
   return query
 }

--- a/src/queries/useAiAnswerQuery.ts
+++ b/src/queries/useAiAnswerQuery.ts
@@ -1,0 +1,40 @@
+import { useEffect } from 'react'
+
+import { useQuery } from '@tanstack/react-query'
+
+import { getAiAnswer } from '@/api'
+import { setStoredAiAnswer } from '@/features/chat-widget/lib/aiAnswerStorage'
+import type { QnaAiAnswer } from '@/types'
+
+type UseAiAnswerQueryOptions = {
+  questionId: number
+  // 서버 응답 전까지 사용할 초기 AI 답변입니다.
+  initialData?: QnaAiAnswer | null
+}
+
+// AI 답변은 버튼 클릭 시점에만 조회되므로 자동 실행을 막고 수동 refetch로 사용합니다.
+export default function useAiAnswerQuery({
+  questionId,
+  initialData = null,
+}: UseAiAnswerQueryOptions) {
+  const query = useQuery({
+    queryKey: ['qna-ai-answer', questionId],
+    queryFn: () => getAiAnswer(questionId),
+    // 답변 카드 열기 전에는 요청하지 않습니다.
+    enabled: false,
+    retry: false,
+    staleTime: Infinity,
+    ...(initialData ? { initialData } : {}),
+  })
+
+  useEffect(() => {
+    if (!query.data) {
+      return
+    }
+
+    // 조회한 답변은 로컬에도 저장해 상세 재진입 시 재사용합니다.
+    setStoredAiAnswer(query.data)
+  }, [query.data])
+
+  return query
+}

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,2 +1,3 @@
 // store
+export { useAiAnswerUiStore } from './useAiAnswerUiStore'
 export { useAuthStore } from './useAuthStore'

--- a/src/store/useAiAnswerUiStore.ts
+++ b/src/store/useAiAnswerUiStore.ts
@@ -1,0 +1,39 @@
+import { create } from 'zustand'
+import { createJSONStorage, persist } from 'zustand/middleware'
+
+type AiAnswerUiState = {
+  // questionId별 AI 답변 카드 열림 여부를 저장합니다.
+  openByQuestionId: Record<number, boolean>
+  // 특정 질문의 AI 답변 카드를 엽니다.
+  openDetail: (questionId: number) => void
+  // 특정 질문의 AI 답변 카드를 닫습니다.
+  closeDetail: (questionId: number) => void
+}
+
+// 상세 페이지에서 AI 답변 카드의 열림/닫힘 상태를 전역으로 관리합니다.
+// persist를 사용해 새로고침 후에도 questionId 기준 UI 상태를 유지합니다.
+export const useAiAnswerUiStore = create<AiAnswerUiState>()(
+  persist(
+    (set) => ({
+      openByQuestionId: {},
+      openDetail: (questionId) =>
+        set((state) => ({
+          openByQuestionId: {
+            ...state.openByQuestionId,
+            [questionId]: true,
+          },
+        })),
+      closeDetail: (questionId) =>
+        set((state) => ({
+          openByQuestionId: {
+            ...state.openByQuestionId,
+            [questionId]: false,
+          },
+        })),
+    }),
+    {
+      name: 'ai-answer-ui-storage',
+      storage: createJSONStorage(() => localStorage),
+    }
+  )
+)

--- a/src/types/api-response/detail.ts
+++ b/src/types/api-response/detail.ts
@@ -1,3 +1,5 @@
+import type { QnaAiAnswer } from './chatbot'
+
 export type QnaAuthor = {
   id: number
   nickname: string
@@ -39,8 +41,10 @@ export type QnaQuestionDetail = {
   images: QnaImage[]
   view_count: number
   created_at: string
+  updated_at?: string
   author: QnaAuthor
   answers: QnaAnswer[]
+  ai_answer?: QnaAiAnswer | null
 }
 
 export type AnswerPermissions = {


### PR DESCRIPTION
## 📌 관련 이슈

Closes #124

## ✨ 변경 내용
  - AI 답변 카드가 질문별로 열림/닫힘 상태를 유지하도록 zustand persist 기반 UI 상태를 추가
  - AI 답변 생성 후 결과를 즉시 재사용할 수 있도록 react-query 조회 로직과 로컬 임시 저장 흐름을 연결
  - 상세 API 응답에 ai_answer 필드를 반영하고, 상세 재진입 시 서버 응답 또는 임시 저장값으로 AI 답변을
    복원하도록 수정
  - AI 답변 카드 반응형 표시를 위해 ChatBadge가 전달받은 className을 루트 요소에 적용하도록 수정

## 📸 스크린샷(선택)
https://github.com/user-attachments/assets/13dc1103-bb07-41c6-b82e-4d118ee4d21f


## 📚 참고사항
  - 현재 AI 답변 상태 유지는 임시 대응입니다.
  - 생성/조회한 AI 답변은 localStorage에 저장하고, 카드 open/close 상태는 zustand persist로 유지하고 있
    습니다.