### PR TITLE
fix: resolve infinite retry loop in axios interceptor

### DIFF
--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -41,6 +41,12 @@ type RetryAxiosRequestConfig = InternalAxiosRequestConfig & {
 }
 
 const handle401Error = async (originalRequest: RetryAxiosRequestConfig) => {
+  // 1. ._retry 제일 먼저 체크 & 세팅
+  if (originalRequest._retry) {
+    return Promise.reject(new Error('Already retried'))
+  }
+  originalRequest._retry = true
+
   if (getIsRefreshing()) {
     // 이미 refresh중이면 queue에 쌓고 대기
     return new Promise<string>((resolve, reject) => {
@@ -52,9 +58,11 @@ const handle401Error = async (originalRequest: RetryAxiosRequestConfig) => {
   }
 
   if (!TokenService.getAccessToken()) {
-    // 토큰 자체가 없으면 refresh 시도안함
     useAuthStore.getState().clearAuth()
-    window.location.href = ROUTES_PATHS.LOGIN
+    // 2. 토큰 자체가 없으면 refresh 시도안함
+    if (window.location.pathname != ROUTES_PATHS.LOGIN) {
+      window.location.href = ROUTES_PATHS.LOGIN
+    }
     return Promise.reject(new Error('No token'))
   }
 
@@ -77,7 +85,9 @@ const handle401Error = async (originalRequest: RetryAxiosRequestConfig) => {
     flushQueue(error, null)
     TokenService.clearTokens()
     useAuthStore.getState().clearAuth()
-    window.location.href = ROUTES_PATHS.LOGIN
+    if (window.location.pathname != ROUTES_PATHS.LOGIN) {
+      window.location.href = ROUTES_PATHS.LOGIN
+    }
     return Promise.reject(error)
   } finally {
     setIsRefreshing(false)

--- a/src/constants/auth-endpoint.ts
+++ b/src/constants/auth-endpoint.ts
@@ -1,4 +1,4 @@
 export const AUTH_API = {
-  ME: '/account/me',
-  REFRESH: '/account/me/refresh',
+  ME: '/accounts/me',
+  REFRESH: '/accounts/me/refresh',
 }


### PR DESCRIPTION
## 📌 관련 이슈

Closes #134 

## ✨ 변경 내용

- accounts/me, accounts/me/refresh URL 오타 수정 (account → accounts)
- handle401Error 함수에 _retry 플래그 조기 세팅 로직 추가
- 이미 로그인 페이지일 경우 중복 redirect 방지 처리 추가

## 📸 스크린샷

https://github.com/user-attachments/assets/20754654-7217-4ec4-a708-f2ab4a274f94

## 📚 참고사항

현재 로그인 페이지는 미구현 상태로 접근 시 Not Found가 표시되는 것이 정상입니다.
토큰이 없을 경우 로그인 경로로 리다이렉트되는 흐름만 구현된 상태입니다.