### PR TITLE
fix:  thumbnail not showing in list

### DIFF
--- a/src/components/common/markdown/toolbar/groups/MediaGroup.tsx
+++ b/src/components/common/markdown/toolbar/groups/MediaGroup.tsx
@@ -5,11 +5,12 @@ import { Image, Link2 } from 'lucide-react'
 
 import { getPresignedUrl, uploadImageToS3 } from '@/api'
 import { Popup } from '@/components'
+import { useToast } from '@/hooks/useToast'
 
 import { Group, IconBtn } from '../ToolbarPrimitives'
 
 type PopupState = {
-  type: 'link' | 'image'
+  type: 'link'
   isOpen: boolean
 }
 
@@ -20,6 +21,7 @@ type MediaGroupProp = {
 
 export default function MediaGroup({ editor, onImageUpload }: MediaGroupProp) {
   const [inputValue, setInputValue] = useState('')
+  const { error } = useToast()
   const [popup, setPopup] = useState<PopupState>({
     type: 'link',
     isOpen: false,
@@ -64,7 +66,7 @@ export default function MediaGroup({ editor, onImageUpload }: MediaGroupProp) {
       onImageUpload?.(img_url)
       editor.chain().focus().setImage({ src: img_url }).run()
     } catch {
-      setPopup({ type: 'image', isOpen: true })
+      error('이미지 업로드에 실패했습니다. 다시 시도해 주세요.')
     }
 
     e.target.value = ''
@@ -114,6 +116,7 @@ export default function MediaGroup({ editor, onImageUpload }: MediaGroupProp) {
         cancelLabel="취소"
         onConfirm={handleConfirm}
         onCancel={closePopup}
+        buttonClassName="px-6"
       />
     </>
   )

--- a/src/components/common/popup/Popup.tsx
+++ b/src/components/common/popup/Popup.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from 'react'
 
 import { Button } from '@/components'
+import { cn } from '@/utils'
 
 type PopupProps = {
   isOpen: boolean
@@ -9,6 +10,7 @@ type PopupProps = {
   onCancel?: () => void
   confirmLabel?: string
   cancelLabel?: string
+  buttonClassName?: string
 }
 
 export default function Popup({
@@ -18,6 +20,7 @@ export default function Popup({
   onCancel,
   confirmLabel = '확인',
   cancelLabel = '취소',
+  buttonClassName,
 }: PopupProps) {
   if (!isOpen) return null
   return (
@@ -39,6 +42,7 @@ export default function Popup({
               variant="outline"
               size="md"
               rounded="full"
+              className={cn('whitespace-nowrap', buttonClassName)}
             >
               {cancelLabel}
             </Button>
@@ -48,6 +52,7 @@ export default function Popup({
             variant="primary"
             size="md"
             rounded="full"
+            className={cn('whitespace-nowrap', buttonClassName)}
           >
             {confirmLabel}
           </Button>

--- a/src/constants/qna-api-endpoints.ts
+++ b/src/constants/qna-api-endpoints.ts
@@ -8,5 +8,5 @@ export const QNA_API = {
   ANSWER_DETAIL: (id: number | string) => `/qna/answers/${id}`,
   ANSWER_COMMENTS: (id: number | string) => `/qna/answers/${id}/comments`,
   ANSWER_ACCEPT: (id: number | string) => `/qna/answers/${id}/accept`,
-  PRESIGNED_URL: '/qna/questions/presigned-url/',
+  PRESIGNED_URL: '/qna/questions/presigned-url',
 } as const

--- a/src/hooks/useQnaForm.ts
+++ b/src/hooks/useQnaForm.ts
@@ -95,14 +95,14 @@ export function useQnaForm(mode: 'create' | 'edit', questionId?: number) {
 
     if (mode === 'create') {
       createQuestion(
-        { title, content, category_id: categoryId! },
+        { title, content, category_id: categoryId!, image_urls: imageUrls },
         {
           onSuccess: () => navigate(ROUTES_PATHS.QNA_LIST),
         }
       )
     } else {
       updateQuestion(
-        { title, content, category_id: categoryId! },
+        { title, content, category_id: categoryId!, image_urls: imageUrls },
         {
           onSuccess: () => navigate(ROUTES_PATHS.QNA_DETAIL_URL(questionId!)),
         }


### PR DESCRIPTION
## 📌 관련 이슈

Closes #135 

## ✨ 변경 내용

- 질문 등록/수정 시 image_urls 필드를 API 요청 본문에 포함하도록 수정
- 기존에 imageUrls 상태에 저장만 하고 전송하지 않던 문제 수정
- MediaGroup: 이미지 업로드 실패 시 팝업 대신 토스트 에러 표시로 변경
- Popup: 버튼 텍스트 줄바꿈 방지를 위해 whitespace-nowrap 클래스 추가
- qna-api-endpoints: presigned-url 경로 슬래시 중복 제거

## 📸 스크린샷

## 📚 참고사항
백엔드에서 thumbnail_img_url 필드가 정상적으로 내려오면 목록에서 이미지가 표시됩니다.
현재 백엔드 수정 요청 중으로, 프론트 작업은 완료된 상태입니다.