### PR TITLE
feat: connect logout API and initialize auth state on app load

### DIFF
--- a/src/AppInitializer.tsx
+++ b/src/AppInitializer.tsx
@@ -1,9 +1,12 @@
 import { useEffect } from 'react'
 
-import { getMe } from '@/api/auth'
-import { useAuthStore } from '@/store/useAuthStore'
+import axios from 'axios'
 
-import { TokenService } from './lib/tokenService'
+import { getMe } from '@/api/auth'
+import { API_BASE_URL } from '@/constants/apiPath'
+import { AUTH_API } from '@/constants/auth-endpoint'
+import { TokenService } from '@/lib/tokenService'
+import { useAuthStore } from '@/store/useAuthStore'
 
 export default function AppInitializer() {
   const setUser = useAuthStore((state) => state.setUser)
@@ -11,20 +14,37 @@ export default function AppInitializer() {
   const setInitialized = useAuthStore((s) => s.setInitialized)
 
   useEffect(() => {
-    // TODO: 로그인 구현 후 제거
-    const devToken = import.meta.env.VITE_ACCESS_TOKEN
-    if (devToken) TokenService.setAccessToken(devToken)
+    const init = async () => {
+      let token = TokenService.getAccessToken()
 
-    const token = TokenService.getAccessToken()
-    if (!token) return
+      if (!token) {
+        // access token 없으면 refresh 먼저 시도
+        try {
+          const { data } = await axios.post(
+            `${API_BASE_URL}${AUTH_API.REFRESH}`,
+            {},
+            { withCredentials: true }
+          )
+          TokenService.setAccessToken(data.access_token)
+          token = data.access_token
+        } catch {
+          // refresh 실패 = 비로그인 상태
+          setInitialized()
+          return
+        }
+      }
 
-    getMe()
-      .then((user) => setUser(user))
-      .catch(() => {
-        TokenService.clearTokens()
-        clearAuth()
-      })
-      .finally(() => setInitialized())
+      // token 있거나 refresh 성공하면 getMe() 호출
+      getMe()
+        .then((user) => setUser(user))
+        .catch(() => {
+          TokenService.clearTokens()
+          clearAuth()
+        })
+        .finally(() => setInitialized())
+    }
+
+    init()
   }, [setUser, clearAuth, setInitialized])
 
   return null

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -58,16 +58,35 @@ const handle401Error = async (originalRequest: RetryAxiosRequestConfig) => {
   }
 
   if (!TokenService.getAccessToken()) {
-    useAuthStore.getState().clearAuth()
-    // 2. 토큰 자체가 없으면 refresh 시도안함
-    if (window.location.pathname != ROUTES_PATHS.LOGIN) {
-      window.location.href = ROUTES_PATHS.LOGIN
+    // 2. access token 없으면 refresh 먼저 시도
+    setIsRefreshing(true)
+    try {
+      const { data } = await axios.post(
+        `${API_BASE_URL}${AUTH_API.REFRESH}`,
+        {},
+        { withCredentials: true }
+      )
+      const newToken = data.access_token
+      TokenService.setAccessToken(newToken)
+      flushQueue(null, newToken)
+
+      originalRequest.headers.Authorization = `Bearer ${newToken}`
+      return api(originalRequest)
+    } catch (error) {
+      flushQueue(error, null)
+      TokenService.clearTokens()
+      useAuthStore.getState().clearAuth()
+      // refresh도 실패하면 로그인으로 이동
+      if (window.location.pathname !== ROUTES_PATHS.LOGIN) {
+        window.location.href = ROUTES_PATHS.LOGIN
+      }
+      return Promise.reject(error)
+    } finally {
+      setIsRefreshing(false)
     }
-    return Promise.reject(new Error('No token'))
   }
 
   setIsRefreshing(true)
-  originalRequest._retry = true
 
   try {
     const { data } = await axios.post(
@@ -85,7 +104,7 @@ const handle401Error = async (originalRequest: RetryAxiosRequestConfig) => {
     flushQueue(error, null)
     TokenService.clearTokens()
     useAuthStore.getState().clearAuth()
-    if (window.location.pathname != ROUTES_PATHS.LOGIN) {
+    if (window.location.pathname !== ROUTES_PATHS.LOGIN) {
       window.location.href = ROUTES_PATHS.LOGIN
     }
     return Promise.reject(error)

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -1,8 +1,13 @@
+import { AUTH_API } from '@/constants/auth-endpoint'
 import type { User } from '@/types'
 
 import { api } from './api'
 
 export const getMe = async (): Promise<User> => {
-  const res = await api.get('/accounts/me')
+  const res = await api.get(AUTH_API.ME)
   return res.data
+}
+
+export const logout = async (): Promise<void> => {
+  await api.post(AUTH_API.LOGOUT)
 }

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,24 +1,30 @@
-import { Link, useNavigate } from 'react-router'
+import { Link } from 'react-router'
 
 import { useQueryClient } from '@tanstack/react-query'
 
+import { logout as logoutApi } from '@/api/auth'
 import Logo from '@/assets/images/logo.png'
-import { EXTERNAL_LINKS, ROUTES_PATHS } from '@/constants'
+import { Avatar } from '@/components'
+import { EXTERNAL_LINKS } from '@/constants'
+import { TokenService } from '@/lib/tokenService'
 import { useAuthStore } from '@/store'
 
-import Avatar from '../common/avatar/Avatar'
-
 export default function Header() {
-  const navigate = useNavigate()
   const queryClient = useQueryClient()
   const isLoggedIn = useAuthStore((state) => state.isLoggedIn)
   const user = useAuthStore((state) => state.user)
   const clearAuth = useAuthStore((state) => state.clearAuth)
 
   const handleLogout = async () => {
+    try {
+      await logoutApi()
+    } catch {
+      // API 실패해도 클라이언트 로그아웃 진행
+    }
+    TokenService.clearTokens()
     clearAuth()
     queryClient.clear()
-    navigate(ROUTES_PATHS.LOGIN)
+    window.location.href = EXTERNAL_LINKS.HOME
   }
 
   return (

--- a/src/features/qna-detail/components/QnaDetailHeader.tsx
+++ b/src/features/qna-detail/components/QnaDetailHeader.tsx
@@ -1,6 +1,6 @@
-import { useNavigate } from 'react-router'
+import { Link, useNavigate } from 'react-router'
 
-import { Link } from 'lucide-react'
+import { Link as LinkIcon } from 'lucide-react'
 
 import { Avatar, Button, CategoryPath } from '@/components'
 import { ROUTES_PATHS } from '@/constants'
@@ -26,7 +26,12 @@ export default function QnaDetailHeader({
 
   return (
     <header className="border-border-line pb-5">
-      <CategoryPath path={category.names} variant="detail" className="mb-4" />
+      <Link
+        to={ROUTES_PATHS.QNA_LIST}
+        className="cursor-pointer transition-opacity hover:opacity-80"
+      >
+        <CategoryPath path={category.names} variant="detail" className="mb-4" />
+      </Link>
       <div className="flex items-start justify-between gap-4">
         <div className="flex min-w-0 flex-1 items-center gap-3">
           <span className="text-primary text-6xl leading-none font-bold">
@@ -76,7 +81,7 @@ export default function QnaDetailHeader({
 
       <div className="border-border-line flex justify-end border-b p-4">
         <Button variant="ghost" size="sm" rounded="full" onClick={onShare}>
-          <Link className="h-4 w-4" />
+          <LinkIcon className="h-4 w-4" />
           공유하기
         </Button>
       </div>


### PR DESCRIPTION
## 📌 관련 이슈

Closes #149 

## ✨ 변경 내용

- 로그아웃 API 연결 및 성공 시 랜딩 페이지로 이동
- 앱 진입 시 액세스 토큰 없으면 silent refresh 후 getMe() 호출하여 인증 상태 초기화
- 카테고리 클릭 시 질문 목록 페이지로 이동하도록 Link 추가
- CategoryPath 컴포넌트 변수명 오타 수정 (constantsVariants → categoryPathVariants)

## 📸 스크린샷(선택)

## 📚 참고사항
로컬 환경에서는 로그인 페이지가 외부 도메인(my.ozcodingschool.site)에 있어 
로그인 상태 유지 여부를 확인할 수 없습니다.
배포 후 실제 환경에서 확인이 필요합니다.