### PR TITLE
fix: sync qna timestamps across list and detail views 

### DIFF
--- a/src/features/qna-detail/components/AnswerCard.tsx
+++ b/src/features/qna-detail/components/AnswerCard.tsx
@@ -3,6 +3,7 @@ import { MessageCircle } from 'lucide-react'
 import { Avatar, Button, Input, ModalButton } from '@/components'
 import { useCommentSort } from '@/hooks'
 import type { SortType } from '@/hooks/useCommentSort'
+import { useMinuteTick } from '@/hooks/useMinuteTick'
 import type { QnaAnswer } from '@/types'
 import { cn, formatTimeAgo } from '@/utils'
 
@@ -32,6 +33,7 @@ export default function AnswerCard({
   onEdit,
   editButtonLabel = '답변 수정하기',
 }: AnswerCardProps) {
+  useMinuteTick()
   const { content, created_at, updated_at, is_adopted, author, comments } =
     answer
   const {

--- a/src/features/qna-detail/components/QnaDetailHeader.tsx
+++ b/src/features/qna-detail/components/QnaDetailHeader.tsx
@@ -5,6 +5,7 @@ import { Link as LinkIcon } from 'lucide-react'
 import { Avatar, Button, CategoryPath } from '@/components'
 import { ROUTES_PATHS } from '@/constants'
 import { AiAnswerCard } from '@/features/chat-widget'
+import { useMinuteTick } from '@/hooks/useMinuteTick'
 import type { QnaQuestionDetail } from '@/types'
 import { formatTimeAgo } from '@/utils'
 
@@ -19,6 +20,7 @@ export default function QnaDetailHeader({
   onShare,
   isQuestionAuthor,
 }: QnaDetailHeaderProps) {
+  useMinuteTick()
   const {
     category,
     title,

--- a/src/features/qna-list/components/QnaCard.tsx
+++ b/src/features/qna-list/components/QnaCard.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router'
 import { AnswerBadge, Avatar, CategoryPath } from '@/components'
 import { ROUTES_PATHS } from '@/constants'
 import type { QnaListItem } from '@/features/qna-list'
+import { useMinuteTick } from '@/hooks/useMinuteTick'
 import { cn, formatTimeAgo } from '@/utils'
 import { removeHtmlTags } from '@/utils/string'
 
@@ -32,10 +33,13 @@ function highlightText(text: string, keyword: string) {
 }
 
 export default function QnaCard({ question, keyword }: QnaCardProps) {
+  useMinuteTick()
   const navigate = useNavigate()
   const hasThumbnail = Boolean(question.thumbnail_img_url)
   const isAnswered = question.answer_count > 0
-  const date = formatTimeAgo(question.created_at)
+  const activityAt =
+    question.update_at ?? question.updated_at ?? question.created_at
+  const date = formatTimeAgo(activityAt)
 
   return (
     <div

--- a/src/features/qna-list/types/qna.type.ts
+++ b/src/features/qna-list/types/qna.type.ts
@@ -29,6 +29,8 @@ export type QnaListItem = {
   answer_count: number
   view_count: number
   created_at: string
+  update_at?: string
+  updated_at?: string
   thumbnail_img_url: string | null
 }
 

--- a/src/queries/useCreateAnswerMutation.ts
+++ b/src/queries/useCreateAnswerMutation.ts
@@ -20,6 +20,9 @@ export default function useCreateAnswerMutation() {
       queryClient.invalidateQueries({
         queryKey: ['qna-detail', variables.questionId],
       })
+      queryClient.invalidateQueries({
+        queryKey: ['qna-list'],
+      })
     },
     onError: () => {
       error('답변 등록에 실패했습니다. 다시 시도해 주세요.')

--- a/src/queries/useCreateQuestionMutation.ts
+++ b/src/queries/useCreateQuestionMutation.ts
@@ -1,14 +1,16 @@
-import { useMutation } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 
 import { createQuestion } from '@/api'
 import { useToast } from '@/hooks/useToast'
 
 export default function useCreateQuestionMutation() {
+  const queryClient = useQueryClient()
   const { success, error } = useToast()
 
   const mutation = useMutation({
     mutationFn: createQuestion,
     onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['qna-list'] })
       success('질문이 등록되었습니다.')
     },
     onError: () => {

--- a/src/queries/useUpdateAnswerMutation.ts
+++ b/src/queries/useUpdateAnswerMutation.ts
@@ -21,6 +21,9 @@ export default function useUpdateAnswerMutation() {
       queryClient.invalidateQueries({
         queryKey: ['qna-detail', variables.questionId],
       })
+      queryClient.invalidateQueries({
+        queryKey: ['qna-list'],
+      })
     },
     onError: () => {
       error('답변 수정에 실패했습니다. 다시 시도해주세요.')

--- a/src/queries/useUpdateQuestionMutation.tsx
+++ b/src/queries/useUpdateQuestionMutation.tsx
@@ -1,16 +1,50 @@
-import { useMutation } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 
 import { updateQuestion } from '@/api'
+import type { QnaListResponse } from '@/features/qna-list'
 import { useToast } from '@/hooks/useToast'
 import type { UpdateQuestionRequest } from '@/types'
 
 export function useUpdateQuestionMutation(questionId: number) {
   const { success, error } = useToast()
+  const queryClient = useQueryClient()
 
   return useMutation({
     mutationFn: (data: UpdateQuestionRequest) =>
       updateQuestion(questionId, data),
-    onSuccess: () => {
+    onSuccess: (updatedQuestion) => {
+      queryClient.setQueryData(['qna-detail', questionId], updatedQuestion)
+      queryClient.setQueriesData<QnaListResponse>(
+        { queryKey: ['qna-list'] },
+        (previous) => {
+          if (!previous) {
+            return previous
+          }
+
+          const nextUpdatedAt =
+            updatedQuestion.update_at ??
+            updatedQuestion.updated_at ??
+            updatedQuestion.created_at
+
+          return {
+            ...previous,
+            results: previous.results.map((question) =>
+              question.id === questionId
+                ? {
+                    ...question,
+                    title: updatedQuestion.title,
+                    category: updatedQuestion.category,
+                    content_preview: updatedQuestion.content,
+                    update_at: nextUpdatedAt,
+                    updated_at: nextUpdatedAt,
+                  }
+                : question
+            ),
+          }
+        }
+      )
+      queryClient.invalidateQueries({ queryKey: ['qna-list'] })
+      queryClient.invalidateQueries({ queryKey: ['qna-detail', questionId] })
       success('질문이 수정되었습니다.')
     },
     onError: () => {

--- a/src/types/api-response/detail.ts
+++ b/src/types/api-response/detail.ts
@@ -29,6 +29,7 @@ export type QnaAnswer = {
   id: number
   content: string
   created_at: string
+  update_at?: string
   updated_at?: string
   is_adopted: boolean
   author: QnaAuthor
@@ -43,6 +44,7 @@ export type QnaQuestionDetail = {
   images: QnaImage[]
   view_count: number
   created_at: string
+  update_at?: string
   updated_at?: string
   author: QnaAuthor
   answers: QnaAnswer[]


### PR DESCRIPTION
## 📌 관련 이슈

Closes #158

## ✨ 변경 내용

  - 질문 등록/수정, 답변 등록/수정 후 시간 정보가 바로 반영되도록 관련 쿼리 갱신 로직을 추가
  - 목록 페이지 카드에서 updated_at/update_at 값을 우선 사용해 수정 시간이 표시되도록 변경
  - 목록/상세/답변 영역의 상대 시간이 1분 단위로 자동 갱신되도록 처리

## 📸 스크린샷(선택)

## 📚 참고사항
