### PR TITLE
fix: fix question update not reflecting immediately

### DIFF
--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -61,7 +61,7 @@ const handle401Error = async (originalRequest: RetryAxiosRequestConfig) => {
     // 2. access token 없으면 refresh 먼저 시도
     setIsRefreshing(true)
     try {
-      const { data } = await axios.post(
+      const { data } = await api.post(
         `${API_BASE_URL}${AUTH_API.REFRESH}`,
         {},
         { withCredentials: true }

--- a/src/hooks/useQnaForm.ts
+++ b/src/hooks/useQnaForm.ts
@@ -1,6 +1,8 @@
 import { useEffect, useMemo, useState } from 'react'
 import { useNavigate } from 'react-router'
 
+import { useQueryClient } from '@tanstack/react-query'
+
 import { ROUTES_PATHS } from '@/constants'
 import { ERROR_MESSAGES } from '@/constants/message'
 import {
@@ -13,6 +15,7 @@ import type { SelectedCategory } from '@/shared/CategoryDropdown'
 import { findSelectedCategory } from '@/utils'
 
 export function useQnaForm(mode: 'create' | 'edit', questionId?: number) {
+  const queryClient = useQueryClient()
   const [title, setTitle] = useState('')
   const [content, setContent] = useState('')
   const [selectedCategory, setSelectedCategory] =
@@ -91,6 +94,7 @@ export function useQnaForm(mode: 'create' | 'edit', questionId?: number) {
    */
   const handleSubmit = () => {
     const error = validate()
+
     if (error) return setPopupMessage(error)
 
     if (mode === 'create') {
@@ -101,15 +105,20 @@ export function useQnaForm(mode: 'create' | 'edit', questionId?: number) {
         }
       )
     } else {
+      if (!questionId) return
       updateQuestion(
         { title, content, category_id: categoryId!, image_urls: imageUrls },
         {
-          onSuccess: () => navigate(ROUTES_PATHS.QNA_DETAIL_URL(questionId!)),
+          onSuccess: async () => {
+            await queryClient.invalidateQueries({
+              queryKey: ['qna-detail', questionId],
+            })
+            navigate(ROUTES_PATHS.QNA_DETAIL_URL(questionId!))
+          },
         }
       )
     }
   }
-
   /**
    * 이미지 업로드 완료 후 URL을 imageUrls 상태에 추가
    * - 질문 등록/수정 시 image_urls 필드에 포함됨

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,4 +1,3 @@
-import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import { BrowserRouter } from 'react-router'
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -18,11 +18,9 @@ const queryClient = new QueryClient()
 
 createRoot(document.getElementById('root')!).render(
   <QueryClientProvider client={queryClient}>
-    <StrictMode>
-      <BrowserRouter>
-        <GlobalToaster />
-        <App />
-      </BrowserRouter>
-    </StrictMode>
+    <BrowserRouter>
+      <GlobalToaster />
+      <App />
+    </BrowserRouter>
   </QueryClientProvider>
 )

--- a/src/pages/qna-create/QnaCreatePage.tsx
+++ b/src/pages/qna-create/QnaCreatePage.tsx
@@ -12,7 +12,7 @@ type QnACreatePageProps = {
 
 export default function QnACreatePage({ mode }: QnACreatePageProps) {
   const { id } = useParams<{ id: string }>()
-  const questionId = Number(id)
+  const questionId = id ? Number(id) : undefined
   const {
     title,
     setTitle,
@@ -73,7 +73,9 @@ export default function QnACreatePage({ mode }: QnACreatePageProps) {
           variant="primary"
           size="lg"
           className="h-9.5 w-28 p-0 text-[clamp(0.875rem,calc(0.663vw+0.72rem),1.25rem)] md:h-13.5 md:w-35"
-          onClick={handleSubmit}
+          onClick={() => {
+            handleSubmit()
+          }}
           disabled={isPending}
         >
           {mode === 'create' ? '등록하기' : '저장하기'}

--- a/src/queries/useUpdateQuestionMutation.tsx
+++ b/src/queries/useUpdateQuestionMutation.tsx
@@ -1,50 +1,19 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 
 import { updateQuestion } from '@/api'
-import type { QnaListResponse } from '@/features/qna-list'
 import { useToast } from '@/hooks/useToast'
 import type { UpdateQuestionRequest } from '@/types'
 
 export function useUpdateQuestionMutation(questionId: number) {
-  const { success, error } = useToast()
   const queryClient = useQueryClient()
+  const { success, error } = useToast()
 
   return useMutation({
     mutationFn: (data: UpdateQuestionRequest) =>
       updateQuestion(questionId, data),
-    onSuccess: (updatedQuestion) => {
-      queryClient.setQueryData(['qna-detail', questionId], updatedQuestion)
-      queryClient.setQueriesData<QnaListResponse>(
-        { queryKey: ['qna-list'] },
-        (previous) => {
-          if (!previous) {
-            return previous
-          }
-
-          const nextUpdatedAt =
-            updatedQuestion.update_at ??
-            updatedQuestion.updated_at ??
-            updatedQuestion.created_at
-
-          return {
-            ...previous,
-            results: previous.results.map((question) =>
-              question.id === questionId
-                ? {
-                    ...question,
-                    title: updatedQuestion.title,
-                    category: updatedQuestion.category,
-                    content_preview: updatedQuestion.content,
-                    update_at: nextUpdatedAt,
-                    updated_at: nextUpdatedAt,
-                  }
-                : question
-            ),
-          }
-        }
-      )
-      queryClient.invalidateQueries({ queryKey: ['qna-list'] })
+    onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['qna-detail', questionId] })
+      queryClient.invalidateQueries({ queryKey: ['qna-ai-answer', questionId] })
       success('질문이 수정되었습니다.')
     },
     onError: () => {


### PR DESCRIPTION
## 📌 관련 이슈

Closes #150 

## ✨ 변경 내용

- useUpdateQuestionMutation: setQueryData 제거 후 invalidateQueries로 변경
- useQnaForm: invalidateQueries await 후 navigate 처리로 순서 보장
- QnaCreatePage: questionId 파싱 안전하게 수정
- api.ts: refresh 요청 시 쿠키에서 refresh_token 추출하여 body에 포함
- main.tsx: StrictMode 제거

## 📸 스크린샷(선택)

## 📚 참고사항
