### PR TITLE
fix: show popup for guest ai answer access

### DIFF
--- a/src/features/chat-widget/components/AiAnswerCard.tsx
+++ b/src/features/chat-widget/components/AiAnswerCard.tsx
@@ -114,6 +114,11 @@ export default function AiAnswerCard({ question }: AiAnswerCardProps) {
   }
 
   const handleToggleDetail = async () => {
+    if (!isLoggedIn) {
+      openUnauthorized()
+      return
+    }
+
     await loadAiAnswer()
   }
 

--- a/src/utils/string.ts
+++ b/src/utils/string.ts
@@ -1,3 +1,8 @@
 export const removeHtmlTags = (html: string) => {
-  return html.replace(/<[^>]*>/g, '').trim()
+  try {
+    const doc = new DOMParser().parseFromString(html, 'text/html')
+    return doc.body.textContent ?? ''
+  } catch {
+    return html.replace(/<[^>]*>?/gm, '').trim()
+  }
 }


### PR DESCRIPTION
## 📌 관련 이슈

Closes #167

## ✨ 변경 내용

- 비회원인 경우 AI 답변 클릭시 로그인 유도 팝업 노출 
- 마크다운 표시 제거  

## 📸 스크린샷
<img width="1284" height="796" alt="스크린샷 2026-04-01 오후 1 02 08" src="https://github.com/user-attachments/assets/a5c10924-60a9-48c8-ab45-0444aa74a330" />

(선택)

## 📚 참고사항
