### PR TITLE
feat: add user profile dropdown menu in header

### DIFF
--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,9 +1,13 @@
+import { useRef, useState } from 'react'
+
 import { useQueryClient } from '@tanstack/react-query'
 
 import { logout as logoutApi } from '@/api/auth'
+import defaultAvatar from '@/assets/images/default-avatar.png'
 import Logo from '@/assets/images/logo.png'
-import { Avatar } from '@/components'
 import { EXTERNAL_LINKS } from '@/constants'
+import { UserMenu } from '@/features'
+import useOutsideClick from '@/hooks/useOutsideClick'
 import { TokenService } from '@/lib/tokenService'
 import { useAuthStore } from '@/store'
 
@@ -12,6 +16,9 @@ export default function Header() {
   const isLoggedIn = useAuthStore((state) => state.isLoggedIn)
   const user = useAuthStore((state) => state.user)
   const clearAuth = useAuthStore((state) => state.clearAuth)
+  const [isDropdownOpen, setIsDropdownOpen] = useState(false)
+  const dropdownRef = useRef<HTMLLIElement>(null)
+  useOutsideClick(dropdownRef, () => setIsDropdownOpen(false))
 
   const handleLogout = async () => {
     try {
@@ -52,19 +59,31 @@ export default function Header() {
             </ul>
           </nav>
         </div>
+
         <nav aria-label="사용자 메뉴">
           <ul className="flex items-center gap-2">
             {isLoggedIn ? (
-              <>
-                <li className="flex items-center py-4">
-                  <Avatar src={user?.profile_img_url ?? undefined} size="sm" />
-                </li>
-                <li className="py-4">
-                  <button type="button" onClick={handleLogout}>
-                    로그아웃
-                  </button>
-                </li>
-              </>
+              <li className="relative py-4" ref={dropdownRef}>
+                <button
+                  type="button"
+                  className="flex cursor-pointer items-center gap-2"
+                  onClick={() => setIsDropdownOpen((prev) => !prev)}
+                >
+                  <img
+                    src={user?.profile_img_url ?? defaultAvatar}
+                    alt="프로필 이미지"
+                    className="pointer-events-none h-6 w-6 rounded-full object-cover"
+                  />
+                </button>
+
+                {isDropdownOpen && (
+                  <UserMenu
+                    userInfo={user}
+                    onLogout={handleLogout}
+                    className="absolute top-full right-0 z-50 mt-2 w-48"
+                  />
+                )}
+              </li>
             ) : (
               <>
                 <li className="py-4">

--- a/src/constants/external-links.ts
+++ b/src/constants/external-links.ts
@@ -4,4 +4,5 @@ export const EXTERNAL_LINKS = {
   COMMUNITY: 'https://community.ozcodingschool.site/posts',
   QNA: 'https://qna.ozcodingschool.site/questions',
   HOME: 'https://my.ozcodingschool.site',
+  MYPAGE: 'https://my.ozcodingschool.site/mypage',
 } as const

--- a/src/features/auth/UserMenu.tsx
+++ b/src/features/auth/UserMenu.tsx
@@ -1,0 +1,52 @@
+import { Button } from '@/components'
+import { EXTERNAL_LINKS } from '@/constants'
+import type { User } from '@/types'
+import { cn } from '@/utils'
+
+type UserMenuProps = {
+  userInfo: User | null
+  onLogout: () => void
+  className?: string
+}
+
+function UserMenu({ userInfo, onLogout, className }: UserMenuProps) {
+  return (
+    <div
+      className={cn(
+        'shadow-modal flex flex-col gap-2.5 rounded-xl bg-white px-4 py-5',
+        className
+      )}
+    >
+      <div className="flex flex-col gap-1 border-b border-gray-200 pb-5">
+        <span className="text-base font-semibold">{userInfo?.nickname}</span>
+        <span className="text-sm text-gray-400">{userInfo?.email}</span>
+      </div>
+      <div className="flex flex-col">
+        <Button variant="text" size="sm" rounded="md" className="justify-start">
+          수강생 등록
+        </Button>
+        <a href={EXTERNAL_LINKS.MYPAGE} className="w-full">
+          <Button
+            variant="text"
+            size="sm"
+            rounded="md"
+            className="w-full justify-start"
+          >
+            마이페이지
+          </Button>
+        </a>
+        <Button
+          variant="text"
+          size="sm"
+          rounded="md"
+          className="justify-start"
+          onClick={onLogout}
+        >
+          로그아웃
+        </Button>
+      </div>
+    </div>
+  )
+}
+
+export default UserMenu

--- a/src/features/index.ts
+++ b/src/features/index.ts
@@ -1,3 +1,4 @@
+export { default as UserMenu } from './auth/UserMenu'
 export { default as ChatView } from './chat-widget/components/ChatView'
 export { default as FloatingChatButton } from './chat-widget/components/FloatingChatButton'
 export { ChatWidgetProvider } from './chat-widget/context/ChatWidgetProvider'


### PR DESCRIPTION


## 📌 관련 이슈

Closes #171 

## ✨ 변경 내용

- 헤더 아바타 클릭 시 드롭다운 메뉴 표시 기능 추가
- UserMenu 컴포넌트를 props 기반(userInfo, onLogout)으로 리팩토링
- useOutsideClick 훅 적용으로 외부 클릭 시 드롭다운 닫기 처리
- 기존 로그아웃 버튼을 UserMenu 내부로 이동

## 📸 스크린샷(선택)

## 📚 참고사항
